### PR TITLE
(bug) onPointsNearLoc returns too many results

### DIFF
--- a/geoFire.js
+++ b/geoFire.js
@@ -487,6 +487,8 @@
         var resultHandler = function(snapshot) {
             var prefix = this.prefix;
             matchesByPrefix[prefix] = [];
+            // clear prior results
+            matchesFiltered.length = 0;
 
             // Compile the results for each of the queries as they return.
             var matchSet = snapshot.val();


### PR DESCRIPTION
Within the searchRadius function, a closure was created around the matchesFiltered array. If setAlert is true, the resultHandler is invoked multiple times and continues to push the same results (and any new results) into the matchesFiltered array. Therefore, if the original query returned 3 results and 1 new object is added to the forge, the query would return 7 data points. The original 3, twice, plus the new data point. Fixed by clearing out the matchesFiltered array within each call to resultHandler.
