### PR TITLE
Updated CI tests to run on latest stable Node and Node 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js:
+- '0.10'
+- '0.12'
 - stable
 sudo: false
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-- '0.10'
 - '0.12'
 - stable
 sudo: false

--- a/tests/specs/common.spec.js
+++ b/tests/specs/common.spec.js
@@ -5,7 +5,7 @@
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 5000;
 
 // Get a reference to a random demo Firebase
-var demoFirebaseUrl = "https://geofire.firebaseio.com";
+var demoFirebaseUrl = 'https://' + generateRandomString() + '.firebaseio-demo.com';
 
 // Define examples of valid and invalid parameters
 var invalidFirebaseRefs = [null, undefined, NaN, true, false, [], 0, 5, "", "a", ["hi", 1]];


### PR DESCRIPTION
Fixes https://github.com/firebase/geofire-js/issues/68. Building still doesn't work on Node 0.10, but I'm going to chalk that up as a won't fix for now. Ideally we would transition off of `gulp-karma` or just switch to Mocha to resolve the build issues. Don't have to time to invest in that right now though.