### PR TITLE
Upgraded Firebase dep to 2.x.x and changed tests to run in Firefox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ node_js:
 - '0.12'
 - stable
 sudo: false
+before_install:
+- export DISPLAY=:99.0
+- sh -e /etc/init.d/xvfb start
 install:
 - npm install -g bower
 - npm install

--- a/bower.json
+++ b/bower.json
@@ -33,8 +33,8 @@
     "changelog.txt"
   ],
   "dependencies": {
-    "firebase": "2.2.x",
-    "rsvp": "3.0.x"
+    "firebase": "2.x.x",
+    "rsvp": "3.1.x"
   },
   "devDependencies": {
     "jasmine": "~2.0.0"

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,12 +8,10 @@ var streamqueue = require("streamqueue");
 var concat = require("gulp-concat");
 var jshint = require("gulp-jshint");
 var uglify = require("gulp-uglify");
+var runSequence = require('run-sequence');
 
 // Testing
 var karma = require("gulp-karma");
-
-// Determine if this is being run in Travis
-var travis = (process.argv.indexOf('--travis') > -1);
 
 
 /****************/
@@ -71,9 +69,7 @@ gulp.task("scripts", function() {
     .pipe(jshint.reporter("jshint-stylish"))
     .pipe(jshint.reporter("fail"))
     .on("error", function(error) {
-      if (travis) {
-        throw error;
-      }
+      throw error;
     })
 
     // Write un-minified version
@@ -120,4 +116,8 @@ gulp.task("watch", function() {
 gulp.task("build", ["scripts"]);
 
 /* Runs the "test" and "scripts" tasks by default */
-gulp.task("default", ["test", "scripts"]);
+gulp.task("default", function(done) {
+  runSequence("scripts", "test", function(error) {
+    done(error && error.err);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -11,12 +11,7 @@
   "bugs": {
     "url": "https://github.com/firebase/geofire-js/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://firebase.mit-license.org/"
-    }
-  ],
+  "license": "MIT",
   "keywords": [
     "geoquery",
     "location",
@@ -32,27 +27,29 @@
     "package.json"
   ],
   "dependencies": {
-    "firebase": "2.2.x",
-    "rsvp": "3.0.x"
+    "firebase": "2.x.x",
+    "rsvp": "3.1.x"
   },
   "devDependencies": {
-    "gulp": "3.8.10",
-    "gulp-concat": "2.4.3",
-    "gulp-ext-replace": "0.1.0",
-    "gulp-jshint": "1.9.0",
-    "gulp-karma": "0.0.4",
-    "gulp-uglify": "1.1.0",
-    "jshint-stylish": "1.0.0",
-    "streamqueue": "0.1.1",
-    "coveralls": "2.11.2",
-    "karma-coverage": "0.2.7",
+    "coveralls": "2.11.4",
+    "gulp": "3.9.0",
+    "gulp-concat": "2.6.0",
+    "gulp-ext-replace": "0.2.0",
+    "gulp-jshint": "1.11.2",
+    "gulp-karma": "0.0.5",
+    "gulp-uglify": "1.4.1",
+    "jshint-stylish": "2.0.1",
+    "karma-chrome-launcher": "0.2.0",
+    "karma-coverage": "0.5.2",
     "karma-failed-reporter": "0.0.3",
-    "karma-jasmine": "0.3.5",
-    "karma-phantomjs-launcher": "0.1.4",
-    "karma-spec-reporter": "0.0.16"
+    "karma-firefox-launcher": "0.1.6",
+    "karma-jasmine": "0.3.6",
+    "karma-spec-reporter": "0.0.20",
+    "run-sequence": "^1.1.4",
+    "streamqueue": "0.1.1"
   },
   "scripts": {
     "test": "gulp test",
-    "travis": "gulp --travis"
+    "travis": "gulp"
   }
 }

--- a/tests/karma.conf.js
+++ b/tests/karma.conf.js
@@ -18,7 +18,7 @@ module.exports = function(config) {
         }
       ]
     },
-    browsers: ["PhantomJS"],
+    browsers: ["Firefox"],
     browserNoActivityTimeout: 30000
   });
 };

--- a/tests/specs/common.spec.js
+++ b/tests/specs/common.spec.js
@@ -19,7 +19,7 @@ var validQueryCriterias = [{center: [0,0], radius: 1000}, {center: [1,-180], rad
 var invalidQueryCriterias = [{}, {random: 100}, {center: [91,2], radius: 1000, random: "a"}, {center: [91,2], radius: 1000}, {center: [1,-181], radius: 1000}, {center: ["a",2], radius: 1000}, {center: [1,[1,2]], radius: 1000}, {center: [0,0], radius: -1}, {center: [null,2], radius: 1000}, {center: [1,undefined], radius: 1000}, {center: [NaN,0], radius: 1000}, {center: [1,2], radius: -10}, {center: [1,2], radius: "text"}, {center: [1,2], radius: [1,2]}, {center: [1,2], radius: null}, true, false, undefined, NaN, [], "a", 1];
 
 // Create global variables to hold the Firebase and GeoFire variables
-var firebaseRef, geoFire, geoQueries;
+var firebaseRef, geoFire, geoQueries = [];
 
 /**********************/
 /*  HELPER FUNCTIONS  */


### PR DESCRIPTION
* Upgraded Firebase dependency to `2.x.x` so we don't have to updated it every time a new minor version of Firebase is released.
* Changed tests to run in Firefox since Firebase does not work in PhantomJS.
* Updated all deps (except `streamqueue`, which has breaking changes).
* Minor gulp cleanup.

Crossing my fingers that the tests pass...