### PR TITLE
Remove RSVP in favour of native Promise

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -15,5 +15,6 @@
   "strict": true,
   "trailing": true,
   "undef": true,
-  "unused": true
+  "unused": true,
+  "esnext": true
 }

--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ and [read our docs for more information about indexing your data](https://www.fi
 In order to use GeoFire in your project, you need to include the following files in your HTML:
 
 ```html
-<!-- RSVP -->
-<script src="rsvp.min.js"></script>
+<!-- ES6 (Promise) Shim -->
+<script src="js/vendor/es6-shim.min.js"></script>
 
 <!-- Firebase -->
 <script src="https://cdn.firebase.com/js/client/2.2.5/firebase.js"></script>
@@ -92,7 +92,7 @@ Use the URL above to download both the minified and non-minified versions of Geo
 Firebase CDN. You can also download them from the
 [releases page of this GitHub repository](https://github.com/firebase/geofire-js/releases).
 [Firebase](https://www.firebase.com/docs/web/quickstart.html?utm_source=geofire-js) and
-[RSVP](https://github.com/tildeio/rsvp.js/) can be downloaded directly from their respective websites.
+[ES6 Shim](https://github.com/paulmillr/es6-shim)
 
 You can also install GeoFire via npm or Bower and its dependencies will be downloaded automatically:
 
@@ -395,7 +395,7 @@ var distance = GeoFire.distance(location1, location2);  // distance === 12378.53
 
 GeoFire uses promises when writing and retrieving data. Promises represent the result of a potentially long-running operation and allow code to run asynchronously. Upon completion of the operation, the promise will be "resolved" / "fulfilled" with the operation's result. This result will be passed to the function defined in the promise's `then()` method.
 
-GeoFire uses the lightweight RSVP.js library to provide an implementation of JavaScript promises. If you are unfamiliar with promises, please refer to the [RSVP.js documentation](https://github.com/tildeio/rsvp.js/). Here is a quick example of how to consume a promise:
+GeoFire uses the lightweight ES6 Shim library to provide a polyfill for the native implementation of JavaScript promises. If you are unfamiliar with promises, please refer to the [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise). Here is a quick example of how to consume a promise:
 
 ```JavaScript
 promise.then(function(result) {

--- a/bower.json
+++ b/bower.json
@@ -34,7 +34,7 @@
   ],
   "dependencies": {
     "firebase": "2.x.x",
-    "rsvp": "3.1.x"
+    "es6-shim": "0.34.x"
   },
   "devDependencies": {
     "jasmine": "~2.0.0"

--- a/build/header
+++ b/build/header
@@ -10,10 +10,5 @@
  * License: MIT
  */
 
-// Include RSVP if this is being run in node
-if (typeof module !== "undefined" && typeof process !== "undefined") {
-  var RSVP = require("rsvp");
-}
-
 var GeoFire = (function() {
   "use strict";

--- a/examples/fish1/index.html
+++ b/examples/fish1/index.html
@@ -6,8 +6,8 @@
     <!-- Firebase -->
     <script src="https://cdn.firebase.com/js/client/2.2.5/firebase.js"></script>
 
-    <!-- RSVP -->
-    <script src="js/vendor/rsvp.min.js"></script>
+    <!-- ES6 (Promise) Shim -->
+    <script src="js/vendor/es6-shim.min.js"></script>
 
     <!-- GeoFire -->
     <script src="js/vendor/geofire.min.js"></script>

--- a/examples/fish1/js/fish1.js
+++ b/examples/fish1/js/fish1.js
@@ -27,7 +27,7 @@
 
   // Once all the fish are in GeoFire, update some of their positions
   var newLocation;
-  RSVP.allSettled(promises).then(function() {
+  Promise.all(promises).then(function() {
     log("*** Updating locations ***");
     newLocation = [-53.435719, 140.808716];
     return geoFire.set("fish1", newLocation);

--- a/examples/fish2/index.html
+++ b/examples/fish2/index.html
@@ -6,8 +6,8 @@
     <!-- Firebase -->
     <script src="https://cdn.firebase.com/js/client/2.2.5/firebase.js"></script>
 
-    <!-- RSVP -->
-    <script src="js/vendor/rsvp.min.js"></script>
+    <!-- ES6 (Promise) Shim -->
+    <script src="js/vendor/es6-shim.min.js"></script>
 
     <!-- GeoFire -->
     <script src="js/vendor/geofire.min.js"></script>

--- a/examples/fish2/js/fish2.js
+++ b/examples/fish2/js/fish2.js
@@ -49,7 +49,7 @@
   });
 
   // Once all the fish are in GeoFire, log a message that the user can now move fish around
-  RSVP.allSettled(promises).then(function() {
+  Promise.all(promises).then(function() {
     log("*** Use the controls above to move the fish in and out of the query ***");
   });
 

--- a/examples/fish3/index.html
+++ b/examples/fish3/index.html
@@ -6,8 +6,8 @@
     <!-- Firebase -->
     <script src="https://cdn.firebase.com/js/client/2.2.5/firebase.js"></script>
 
-    <!-- RSVP -->
-    <script src="js/vendor/rsvp.min.js"></script>
+    <!-- ES6 (Promise) Shim -->
+    <script src="js/vendor/es6-shim.min.js"></script>
 
     <!-- GeoFire -->
     <script src="js/vendor/geofire.min.js"></script>

--- a/examples/fish3/js/fish3.js
+++ b/examples/fish3/js/fish3.js
@@ -26,7 +26,7 @@
   });
 
   // Once all the fish are in GeoFire, log a message that the user can now move fish around
-  RSVP.allSettled(promises).then(function() {
+  Promise.all(promises).then(function() {
     log("*** Creating GeoQuery ***");
     // Create a GeoQuery centered at fish2
     var geoQuery = geoFire.query({

--- a/examples/html5Geolocation/index.html
+++ b/examples/html5Geolocation/index.html
@@ -6,8 +6,8 @@
     <!-- Firebase -->
     <script src="https://cdn.firebase.com/js/client/2.2.5/firebase.js"></script>
 
-    <!-- RSVP -->
-    <script src="js/vendor/rsvp.min.js"></script>
+    <!-- ES6 (Promise) Shim -->
+    <script src="js/vendor/es6-shim.min.js"></script>
 
     <!-- GeoFire -->
     <script src="js/vendor/geofire.min.js"></script>

--- a/examples/queryBuilder/index.html
+++ b/examples/queryBuilder/index.html
@@ -9,8 +9,8 @@
     <!-- Firebase -->
     <script src="https://cdn.firebase.com/js/client/2.2.5/firebase.js"></script>
 
-    <!-- RSVP -->
-    <script src="js/vendor/rsvp.min.js"></script>
+    <!-- ES6 (Promise) Shim -->
+    <script src="js/vendor/es6-shim.min.js"></script>
 
     <!-- GeoFire -->
     <script src="js/vendor/geofire.min.js"></script>

--- a/examples/sfVehicles/index.html
+++ b/examples/sfVehicles/index.html
@@ -86,8 +86,8 @@
   <!-- Firebase -->
   <script src="https://cdn.firebase.com/js/client/2.2.5/firebase.js"></script>
 
-  <!-- RSVP -->
-  <script src="js/vendor/rsvp.min.js"></script>
+  <!-- ES6 (Promise) Shim -->
+    <script src="js/vendor/es6-shim.min.js"></script>
 
   <!-- GeoFire -->
   <script src="js/vendor/geofire.min.js"></script>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -40,7 +40,7 @@ var paths = {
     config: "tests/karma.conf.js",
     files: [
       "bower_components/firebase/firebase.js",
-      "bower_components/rsvp/rsvp.min.js",
+      "bower_components/es6-shim/es6-shim.min.js",
       "src/*.js",
       "tests/specs/*.spec.js"
     ]

--- a/migration/migrateToV3.js
+++ b/migration/migrateToV3.js
@@ -1,5 +1,4 @@
 var Firebase = require('firebase');
-var RSVP = require('rsvp');
 var args = process.argv
 
 function usage() {
@@ -11,7 +10,7 @@ function usage() {
 }
 
 function setWithPromise(ref, value, priority) {
-  return new RSVP.Promise(function(resolve, reject) {
+  return new Promise(function(resolve, reject) {
     if (priority) {
       ref.setWithPriority(value, priority, function(error) {
         if (error) {
@@ -52,7 +51,7 @@ function runMigration(fromFirebase, toFirebase, inPlace) {
           var hash = parts[0];
           var key = parts.splice(1).join(":");
           (function(key, hash) {
-            var promise = new RSVP.Promise(function(resolve, reject) {
+            var promise = new Promise(function(resolve, reject) {
               fromFirebase.child('l').child(key).once('value', function(snapshot) {
                 resolve(snapshot.val());
               }, function(error) {
@@ -76,7 +75,7 @@ function runMigration(fromFirebase, toFirebase, inPlace) {
           })(key, hash);
         }
       });
-      RSVP.all(promises).then(function(posts) {
+      Promise.all(promises).then(function(posts) {
         if (error) {
           console.log("There were errors migrating GeoFire, please check your data and the result manually");
           process.exit(1);
@@ -84,7 +83,7 @@ function runMigration(fromFirebase, toFirebase, inPlace) {
           console.log("Migrated " + promises.length + " keys successfully!");
           if (inPlace) {
             console.log("Deleting old keys");
-            return RSVP.all([
+            return Promise.all([
               setWithPromise(fromFirebase.child('l'), null),
               setWithPromise(fromFirebase.child('i'), null),
             ]);

--- a/migration/package.json
+++ b/migration/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "rsvp": "3.0.9",
+    "es6-shim": "0.34.x",
     "firebase": "1.0.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "coveralls": "2.11.4",
     "gulp": "3.9.0",
+	"bower": "1.7.x",
     "gulp-concat": "2.6.0",
     "gulp-ext-replace": "0.2.0",
     "gulp-jshint": "1.11.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "dependencies": {
     "firebase": "2.x.x",
-    "rsvp": "3.1.x"
+    "es6-shim": "0.34.x"
   },
   "devDependencies": {
     "coveralls": "2.11.4",

--- a/src/geoFire.js
+++ b/src/geoFire.js
@@ -60,7 +60,7 @@ var GeoFire = function(firebaseRef) {
       }
     });
 
-    return new RSVP.Promise(function(resolve, reject) {
+    return new Promise(function(resolve, reject) {
       function onComplete(error) {
         if (error !== null) {
           reject("Error: Firebase synchronization failed: " + error);
@@ -84,7 +84,7 @@ var GeoFire = function(firebaseRef) {
    */
   this.get = function(key) {
     validateKey(key);
-    return new RSVP.Promise(function(resolve, reject) {
+    return new Promise(function(resolve, reject) {
       _firebaseRef.child(key).once("value", function(dataSnapshot) {
         if (dataSnapshot.val() === null) {
           resolve(null);

--- a/tests/index.html
+++ b/tests/index.html
@@ -9,8 +9,8 @@
     <script src="../bower_components/jasmine/lib/jasmine-core/boot.js"></script>
     <link rel="stylesheet" href="../bower_components/jasmine/lib/jasmine-core/jasmine.css">
 
-    <!-- RSVP -->
-    <script src="../bower_components/rsvp/rsvp.min.js"></script>
+    <!-- ES6 (Promise) Shim -->
+    <script src="../bower_components/es6-shim/es6-shim.min.js"></script>
 
     <!-- Firebase -->
     <script src="../bower_components/firebase/firebase.js"></script>

--- a/tests/specs/common.spec.js
+++ b/tests/specs/common.spec.js
@@ -72,7 +72,7 @@ function generateRandomString() {
 
 /* Returns the current data in the Firebase */
 function getFirebaseData() {
-  return new RSVP.Promise(function(resolve, reject) {
+  return new Promise(function(resolve, reject) {
     firebaseRef.once("value", function(dataSnapshot) {
       resolve(dataSnapshot.exportVal());
     });
@@ -82,7 +82,7 @@ function getFirebaseData() {
 
 /* Returns a promise which is fulfilled after the inputted number of milliseconds pass */
 function wait(milliseconds) {
-  return new RSVP.Promise(function(resolve, reject) {
+  return new Promise(function(resolve, reject) {
     var timeout = window.setTimeout(function() {
       window.clearTimeout(timeout);
       resolve();


### PR DESCRIPTION
I was not able to test this as some of the npm deps could not be install, but I am sure that everything should be running properly.

Also, some of the npm packages are deprecated (`gulp-karma`), it may be a good idea to update the dev deps and the gulp tasks.

It might also be a good idea to start using ES6 and use a simple transpile to ES5 task for creating dist packages.

Implements https://github.com/firebase/geofire-js/issues/84.