### PR TITLE
Add GeoFire.getUpdateData() to enable multi location updates.

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -19,6 +19,7 @@
    - [`cancel()`](#geocallbackregistrationcancel)
  * [Helper Methods](#helper-methods)
    - [`GeoFire.distance(location1, location2)`](#geofiredistancelocation1-location2)
+   - [`GeoFire.getUpdateData(keyOrLocations[, location])`](#geofiregetupdatedatakeyorlocations-location)
  * [Promises](#promises)
 
 
@@ -303,6 +304,31 @@ var location1 = [10.3, -55.3];
 var location2 = [-78.3, 105.6];
 
 var distance = GeoFire.distance(location1, location2);  // distance === 12378.536597423461
+```
+
+### GeoFire.getUpdateData(keyOrLocations[, location])
+
+Static helper method which has the same input as `GeoFire.set()`. The difference is that this method does not do the update automatically,
+instead it returns the update data which can later be used to do a multi location update manually.
+
+```JavaScript
+var firebaseRef = firebase.database().ref();
+
+// Generate a new push ID for the new post
+var newPostRef = ref.child("posts").push();
+var newPostKey = newPostRef.key();
+
+// Create the data we want to update
+var updatedUserData = {};
+updatedUserData["user/posts/" + newPostKey] = true;
+updatedUserData["posts/" + newPostKey] = {
+  title: "New Post",
+  content: "Here is my new post!"
+};
+updatedUserData["location"] = GeoFire.getUpdateData(newPostKey, [37.79, -122.41]);
+
+// Do a deep-path update
+ref.update(updatedUserData);
 ```
 
 

--- a/src/geoFire.js
+++ b/src/geoFire.js
@@ -29,37 +29,8 @@ var GeoFire = function(firebaseRef) {
    * @return {Promise.<>} A promise that is fulfilled when the write is complete.
    */
   this.set = function(keyOrLocations, location) {
-    var locations;
-    if (typeof keyOrLocations === "string" && keyOrLocations.length !== 0) {
-      // If this is a set for a single location, convert it into a object
-      locations = {};
-      locations[keyOrLocations] = location;
-    } else if (typeof keyOrLocations === "object") {
-      if (typeof location !== "undefined") {
-        throw new Error("The location argument should not be used if you pass an object to set().");
-      }
-      locations = keyOrLocations;
-    } else {
-      throw new Error("keyOrLocations must be a string or a mapping of key - location pairs.");
-    }
-
-    var newData = {};
-
-    Object.keys(locations).forEach(function(key) {
-      validateKey(key);
-
-      var location = locations[key];
-      if (location === null) {
-        // Setting location to null is valid since it will remove the key
-        newData[key] = null;
-      } else {
-        validateLocation(location);
-
-        var geohash = encodeGeohash(location);
-        newData[key] = encodeGeoFireObject(location, geohash);
-      }
-    });
-
+    // Encode the key - location pair(s).
+    var newData = GeoFire.getUpdateData(keyOrLocations, location);
     return _firebaseRef.update(newData);
   };
 
@@ -139,4 +110,47 @@ GeoFire.distance = function(location1, location2) {
   var c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
 
   return radius * c;
+};
+
+/**
+ * Static method which encodes the provided key - location pair(s). The encoded data can be used for atomic multi location update.
+ *
+ * @param {string|Object} keyOrLocations The key representing the location to add or a mapping of key - location pairs which
+ * represent the locations to add.
+ * @param {Array.<number>|undefined} location The [latitude, longitude] pair to add.
+ * @return {Object.<string, Object>} Mapping of key - location pairs where the location is encoded as GeoFire object.
+ */
+GeoFire.getUpdateData = function(keyOrLocations, location) {
+  var locations;
+  if (typeof keyOrLocations === "string" && keyOrLocations.length !== 0) {
+    // If this is a set for a single location, convert it into a object
+    locations = {};
+    locations[keyOrLocations] = location;
+  } else if (typeof keyOrLocations === "object") {
+    if (typeof location !== "undefined") {
+      throw new Error("The location argument should not be used if you pass an object to set().");
+    }
+    locations = keyOrLocations;
+  } else {
+    throw new Error("keyOrLocations must be a string or a mapping of key - location pairs.");
+  }
+
+  var newData = {};
+
+  Object.keys(locations).forEach(function(key) {
+    validateKey(key);
+
+    var location = locations[key];
+    if (location === null) {
+      // Setting location to null is valid since it will remove the key
+      newData[key] = null;
+    } else {
+      validateLocation(location);
+
+      var geohash = encodeGeohash(location);
+      newData[key] = encodeGeoFireObject(location, geohash);
+    }
+  });
+
+  return newData;
 };


### PR DESCRIPTION
### Description

Finishes #76.
Add a static method on GeoFire to enable retrieving encoded location that can later be used in a multi location database update.

### Code sample

```JavaScript
var firebaseRef = firebase.database().ref();

// Generate a new push ID for the new post
var newPostRef = ref.child("posts").push();
var newPostKey = newPostRef.key();

// Create the data we want to update
var updatedUserData = {};
updatedUserData["user/posts/" + newPostKey] = true;
updatedUserData["posts/" + newPostKey] = {
  title: "New Post",
  content: "Here is my new post!"
};
updatedUserData["location"] = GeoFire.getUpdateData(newPostKey, [37.79, -122.41]);

// Do a deep-path update
ref.update(updatedUserData);
```

### Notes

I am not sure about the name of the method. If you have a better suggestion I am happy to change it. :)

