### PR TITLE
updateCriteria({radius: 0}) is ignored.

### DIFF
--- a/src/geoQuery.js
+++ b/src/geoQuery.js
@@ -361,8 +361,12 @@ var GeoQuery = function (firebaseRef, queryCriteria) {
   this.updateCriteria = function(newQueryCriteria) {
     // Validate and save the new query criteria
     validateCriteria(newQueryCriteria);
-    _center = newQueryCriteria.center || _center;
-    _radius = newQueryCriteria.radius || _radius;
+    if (typeof newQueryCriteria.center !== "undefined" && newQueryCriteria.center !== null) {
+      _center = newQueryCriteria.center;
+    }
+    if (typeof newQueryCriteria.radius !== "undefined" && newQueryCriteria.radius !== null) {
+      _radius = newQueryCriteria.radius;
+    }
 
     // Loop through all of the locations in the query, update their distance from the center of the
     // query, and fire any appropriate events

--- a/tests/specs/geoQuery.spec.js
+++ b/tests/specs/geoQuery.spec.js
@@ -286,11 +286,22 @@ describe("GeoQuery Tests:", function() {
       }).catch(failTestOnCaughtError);
     });
 
-    it("updateCriteria() does not throw errors given valid query criteria", function() {
+    it("updateCriteria() updates query criteria when given valid query criteria", function() {
       geoQueries.push(geoFire.query({center: [1,2], radius: 1000}));
 
+      expect(geoQueries[0].center()).toEqual([1,2]);
+      expect(geoQueries[0].radius()).toEqual(1000);
+
       validQueryCriterias.forEach(function(validQueryCriteria) {
-        expect(function() { geoQueries[0].updateCriteria(validQueryCriteria); }).not.toThrow();
+        geoQueries[0].updateCriteria(validQueryCriteria);
+
+        if ('center' in validQueryCriteria) {
+          expect(geoQueries[0].center()).toEqual(validQueryCriteria.center);
+        }
+
+        if ('radius' in validQueryCriteria) {
+          expect(geoQueries[0].radius()).toEqual(validQueryCriteria.radius);
+        }
       });
     });
 


### PR DESCRIPTION
Noticed that updating the radius of a query to 0 doesn't have any effect on it:

```javascript
var geoQuery = geoFire.query({center: [1,2], radius: 1000})

expect(geoQuery.radius()).toEqual(1000); /* passes */
geoQuery.updateCriteria({radius: 0});
expect(geoQuery.radius()).toEqual(0); /* fails */
```