### PR TITLE
Removing priority checks from security rules

### DIFF
--- a/examples/securityRules/authenticated.rules.json
+++ b/examples/securityRules/authenticated.rules.json
@@ -13,11 +13,11 @@
         ".write": "auth !== null",
 
         // Key validation
-        ".validate": "newData.hasChildren(['g', 'l']) && newData.getPriority().length <= 22 && newData.getPriority().length > 0",
+        ".validate": "newData.hasChildren(['g', 'l'])",
 
         // Geohash validation
         "g": {
-          ".validate": "newData.val() == newData.parent().getPriority()"
+          ".validate": "newData.isString() && newData.val().length <= 22 && newData.val().length > 0"
         },
 
         // Location coordinates validation

--- a/examples/securityRules/noDeletes.rules.json
+++ b/examples/securityRules/noDeletes.rules.json
@@ -13,11 +13,11 @@
         ".write": "newData.exists()",
 
         // Key validation
-        ".validate": "newData.hasChildren(['g', 'l']) && newData.getPriority().length <= 22 && newData.getPriority().length > 0",
+        ".validate": "newData.hasChildren(['g', 'l'])",
 
         // Geohash validation
         "g": {
-          ".validate": "newData.val() == newData.parent().getPriority()"
+          ".validate": "newData.isString() && newData.val().length <= 22 && newData.val().length > 0"
         },
 
         // Location coordinates validation

--- a/examples/securityRules/noUpdates.rules.json
+++ b/examples/securityRules/noUpdates.rules.json
@@ -13,11 +13,11 @@
         ".write": "!data.exists()",
 
         // Key validation
-        ".validate": "newData.hasChildren(['g', 'l']) && newData.getPriority().length <= 22 && newData.getPriority().length > 0",
+        ".validate": "newData.hasChildren(['g', 'l'])",
 
         // Geohash validation
         "g": {
-          ".validate": "newData.val() == newData.parent().getPriority()"
+          ".validate": "newData.isString() && newData.val().length <= 22 && newData.val().length > 0"
         },
 
         // Location coordinates validation

--- a/examples/securityRules/rules.json
+++ b/examples/securityRules/rules.json
@@ -13,11 +13,11 @@
         ".write": true,
 
         // Key validation
-        ".validate": "newData.hasChildren(['g', 'l']) && newData.getPriority().length <= 22 && newData.getPriority().length > 0",
+        ".validate": "newData.hasChildren(['g', 'l'])",
 
         // Geohash validation
         "g": {
-          ".validate": "newData.val() == newData.parent().getPriority()"
+          ".validate": "newData.isString() && newData.val().length <= 22 && newData.val().length > 0"
         },
 
         // Location coordinates validation


### PR DESCRIPTION
We no longer use priority, so we should remove the priority checks from security rules.