### PR TITLE
fix(examples): update examples to use geofire 5.x.x and firebase 5.x.x, fixes #182

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,14 @@ queries.
 A compatible GeoFire client is also available for [Objective-C](https://github.com/firebase/geofire-objc)
 and [Java](https://github.com/firebase/geofire-java).
 
-
 ## Table of Contents
 
- * [Downloading GeoFire](#downloading-geofire)
- * [Documentation](#documentation)
- * [Examples](#examples)
- * [Release Notes](https://github.com/firebase/geofire-js/releases)
- * [Migration Guides](#migration-guides)
- * [Contributing](#contributing)
+* [Downloading GeoFire](#downloading-geofire)
+* [Documentation](#documentation)
+* [Examples](#examples)
+* [Release Notes](https://github.com/firebase/geofire-js/releases)
+* [Migration Guides](#migration-guides)
+* [Contributing](#contributing)
 
 
 ## Downloading GeoFire
@@ -35,7 +34,8 @@ In order to use GeoFire in your project, you need to include the following files
 
 ```html
 <!-- Firebase -->
-<script src="https://www.gstatic.com/firebasejs/3.7.0/firebase.js"></script>
+<script src="https://www.gstatic.com/firebasejs/5.9.4/firebase-app.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/5.9.4/firebase-database.js"></script>
 
 <!-- GeoFire -->
 <script src="https://cdn.firebase.com/libs/geofire/5.0.1/geofire.min.js"></script>
@@ -62,7 +62,6 @@ $ bower install geofire --save
 
 * [API Reference](docs/reference.md)
 
-
 ## Examples
 
 You can find a full list of our demos and view the code for each of them in the
@@ -79,12 +78,10 @@ location for each bar using GeoFire, using the bar IDs as GeoFire keys. GeoFire 
 easily query which bar IDs (the keys) are nearby. To display any additional information about the
 bars, you can load the information for each bar returned by the query at `/bars/<bar-id>`.
 
-
 ## Migration Guides
 
 Using an older version of GeoFire and want to upgrade to the latest version? Check out our
 [migration guides](docs/migration.md) to find out how!
-
 
 ## Contributing
 

--- a/examples/fish1/index.html
+++ b/examples/fish1/index.html
@@ -4,13 +4,14 @@
     <title>GeoFire fish1 Example</title>
 
     <!-- Firebase -->
-    <script src="https://www.gstatic.com/firebasejs/live/3.0/firebase.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/5.9.4/firebase-app.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/5.9.4/firebase-database.js"></script>
 
     <!-- RSVP -->
     <script src="https://unpkg.com/rsvp@3.1.0/dist/rsvp.min.js"></script>
 
     <!-- GeoFire -->
-    <script src="https://cdn.firebase.com/libs/geofire/4.1.0/geofire.min.js"></script>
+    <script src="https://cdn.firebase.com/libs/geofire/5.0.1/geofire.min.js"></script>
 
     <!-- Custom JS -->
     <script src="js/fish1.js" defer></script>

--- a/examples/fish1/js/fish1.js
+++ b/examples/fish1/js/fish1.js
@@ -9,7 +9,7 @@
   var firebaseRef = firebase.database().ref().push();
 
   // Create a new GeoFire instance at the random Firebase location
-  var geoFire = new GeoFire(firebaseRef);
+  var geoFireInstance = new geofire.GeoFire(firebaseRef);
 
   // Specify the locations for each fish
   var fishLocations = [
@@ -22,7 +22,7 @@
   // Set the initial locations of the fish in GeoFire
   log("*** Setting initial locations ***");
   var promises = fishLocations.map(function(location, index) {
-    return geoFire.set("fish" + index, location).then(function() {
+    return geoFireInstance.set("fish" + index, location).then(function() {
       log("fish" + index + " initially set to [" + location + "]");
     });
   });
@@ -32,16 +32,16 @@
   RSVP.allSettled(promises).then(function() {
     log("*** Updating locations ***");
     newLocation = [-53.435719, 140.808716];
-    return geoFire.set("fish1", newLocation);
+    return geoFireInstance.set("fish1", newLocation);
   }).then(function() {
     log("fish1 moved to [" + newLocation + "]");
 
     newLocation = [56.83069, 1.94822];
-    return geoFire.set("fish2", newLocation);
+    return geoFireInstance.set("fish2", newLocation);
   }).then(function() {
     log("fish2 moved to [" + newLocation + "]");
 
-    return geoFire.remove("fish0");
+    return geoFireInstance.remove("fish0");
   }).then(function() {
     log("fish0 removed from GeoFire");
 
@@ -55,7 +55,7 @@
   document.getElementById("getFishLocation").addEventListener("click", function() {
     var selectedFishKey = document.getElementById("fishSelect").value;
 
-    geoFire.get(selectedFishKey).then(function(location) {
+    geoFireInstance.get(selectedFishKey).then(function(location) {
       if (location === null) {
         log( selectedFishKey + " is not in GeoFire");
       }

--- a/examples/fish2/index.html
+++ b/examples/fish2/index.html
@@ -4,13 +4,14 @@
     <title>GeoFire fish2 Example</title>
 
     <!-- Firebase -->
-    <script src="https://www.gstatic.com/firebasejs/live/3.0/firebase.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/5.9.4/firebase-app.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/5.9.4/firebase-database.js"></script>
 
     <!-- RSVP -->
     <script src="https://unpkg.com/rsvp@3.1.0/dist/rsvp.min.js"></script>
 
     <!-- GeoFire -->
-    <script src="https://cdn.firebase.com/libs/geofire/4.1.0/geofire.min.js"></script>
+    <script src="https://cdn.firebase.com/libs/geofire/5.0.1/geofire.min.js"></script>
 
     <!-- Custom JS -->
     <script src="js/fish2.js" defer></script>

--- a/examples/fish2/js/fish2.js
+++ b/examples/fish2/js/fish2.js
@@ -9,7 +9,7 @@
   var firebaseRef = firebase.database().ref().push();
 
   // Create a new GeoFire instance at the random Firebase location
-  var geoFire = new GeoFire(firebaseRef);
+  var geoFireInstance = new geofire.GeoFire(firebaseRef);
 
   // Create the locations for each fish
   var fishLocations = [
@@ -20,7 +20,7 @@
   ];
 
   // Create a GeoQuery centered at fish2
-  var geoQuery = geoFire.query({
+  var geoQuery = geoFireInstance.query({
     center: fishLocations[2],
     radius: 3000
   });
@@ -47,7 +47,7 @@
   // Set the initial locations of the fish in GeoFire
   log("*** Setting initial locations ***");
   var promises = fishLocations.map(function(location, index) {
-    return geoFire.set("fish" + index, location);
+    return geoFireInstance.set("fish" + index, location);
   });
 
   // Once all the fish are in GeoFire, log a message that the user can now move fish around
@@ -83,7 +83,7 @@
       }
     };
 
-    geoFire.set(selectedFishKey, newLocations[selectedFishKey][selectedLocation]);
+    geoFireInstance.set(selectedFishKey, newLocations[selectedFishKey][selectedLocation]);
   });
 
   // Cancel the "key_moved" callback when the corresponding button is clicked

--- a/examples/fish3/index.html
+++ b/examples/fish3/index.html
@@ -1,16 +1,17 @@
 <!DOCTYPE HTML>
 <html>
   <head>
-    <title>GeoFire fish2 Example</title>
+    <title>GeoFire fish3 Example</title>
 
     <!-- Firebase -->
-    <script src="https://www.gstatic.com/firebasejs/live/3.0/firebase.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/5.9.4/firebase-app.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/5.9.4/firebase-database.js"></script>
 
     <!-- RSVP -->
     <script src="https://unpkg.com/rsvp@3.1.0/dist/rsvp.min.js"></script>
 
     <!-- GeoFire -->
-    <script src="https://cdn.firebase.com/libs/geofire/4.1.0/geofire.min.js"></script>
+    <script src="https://cdn.firebase.com/libs/geofire/5.0.1/geofire.min.js"></script>
 
     <!-- Custom JS -->
     <script src="js/fish3.js" defer></script>

--- a/examples/fish3/js/fish3.js
+++ b/examples/fish3/js/fish3.js
@@ -9,7 +9,7 @@
   var firebaseRef = firebase.database().ref().push();
 
   // Create a new GeoFire instance at the random Firebase location
-  var geoFire = new GeoFire(firebaseRef);
+  var geoFireInstance = new geofire.GeoFire(firebaseRef);
 
   // Create the locations for each fish
   var fishLocations = [
@@ -22,7 +22,7 @@
   // Set the initial locations of the fish in GeoFire
   log("*** Setting initial locations ***");
   var promises = fishLocations.map(function(location, index) {
-    return geoFire.set("fish" + index, location).then(function() {
+    return geoFireInstance.set("fish" + index, location).then(function() {
       log("fish" + index + " initially set to [" + location + "]");
     });
   });
@@ -31,7 +31,7 @@
   RSVP.allSettled(promises).then(function() {
     log("*** Creating GeoQuery ***");
     // Create a GeoQuery centered at fish2
-    var geoQuery = geoFire.query({
+    var geoQuery = geoFireInstance.query({
       center: fishLocations[2],
       radius: 3000
     });

--- a/examples/html5Geolocation/index.html
+++ b/examples/html5Geolocation/index.html
@@ -4,10 +4,11 @@
     <title>GeoFire HTML5 Geolocation API Example</title>
 
     <!-- Firebase -->
-    <script src="https://www.gstatic.com/firebasejs/live/3.0/firebase.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/5.9.4/firebase-app.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/5.9.4/firebase-database.js"></script>
 
     <!-- GeoFire -->
-    <script src="https://cdn.firebase.com/libs/geofire/4.1.0/geofire.min.js"></script>
+    <script src="https://cdn.firebase.com/libs/geofire/5.0.1/geofire.min.js"></script>
 
     <!-- Custom JS -->
     <script src="js/html5Geolocation.js" defer></script>

--- a/examples/html5Geolocation/js/html5Geolocation.js
+++ b/examples/html5Geolocation/js/html5Geolocation.js
@@ -9,7 +9,7 @@
   var firebaseRef = firebase.database().ref().push();
 
   // Create a new GeoFire instance at the random Firebase location
-  var geoFire = new GeoFire(firebaseRef);
+  var geoFireInstance = new geofire.GeoFire(firebaseRef);
 
   /* Uses the HTML5 geolocation API to get the current user's location */
   var getLocation = function() {
@@ -28,7 +28,7 @@
     log("Retrieved user's location: [" + latitude + ", " + longitude + "]");
 
     var username = "wesley";
-    geoFire.set(username, [latitude, longitude]).then(function() {
+    geoFireInstance.set(username, [latitude, longitude]).then(function() {
       log("Current user " + username + "'s location has been added to GeoFire");
 
       // When the user disconnects from Firebase (e.g. closes the app, exits the browser),

--- a/examples/queryBuilder/index.html
+++ b/examples/queryBuilder/index.html
@@ -7,10 +7,11 @@
     <script src="https://code.jquery.com/jquery-2.2.1.min.js"></script>
 
     <!-- Firebase -->
-    <script src="https://www.gstatic.com/firebasejs/live/3.0/firebase.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/5.9.4/firebase-app.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/5.9.4/firebase-database.js"></script>
 
     <!-- GeoFire -->
-    <script src="https://cdn.firebase.com/libs/geofire/4.1.0/geofire.min.js"></script>
+    <script src="https://cdn.firebase.com/libs/geofire/5.0.1/geofire.min.js"></script>
 
     <!-- Custom JS -->
     <script src="js/queryBuilder.js" defer></script>

--- a/examples/queryBuilder/js/queryBuilder.js
+++ b/examples/queryBuilder/js/queryBuilder.js
@@ -9,7 +9,7 @@
   var firebaseRef = firebase.database().ref().push();
 
   // Create a new GeoFire instance at the random Firebase location
-  var geoFire = new GeoFire(firebaseRef);
+  var geoFireInstance = new geofire.GeoFire(firebaseRef);
   var geoQuery;
 
   $("#addfish").on("submit", function() {
@@ -17,7 +17,7 @@
     var lon = parseFloat($("#addlon").val());
     var myID = "fish-" + firebaseRef.push().key;
 
-    geoFire.set(myID, [lat, lon]).then(function() {
+    geoFireInstance.set(myID, [lat, lon]).then(function() {
       log(myID + ": setting position to [" + lat + "," + lon + "]");
     });
 
@@ -41,7 +41,7 @@
     } else {
       operation = "Creating";
 
-      geoQuery = geoFire.query({
+      geoQuery = geoFireInstance.query({
         center: [lat, lon],
         radius: radius
       });


### PR DESCRIPTION
### Description

Update the example applications to use Firebase 5.x.x and GeoFire 5.x.x

### Code sample

In the head of the HTML files:

```HTML
<!-- Firebase -->
<script src="https://www.gstatic.com/firebasejs/5.9.4/firebase-app.js"></script>
<script src="https://www.gstatic.com/firebasejs/5.9.4/firebase-database.js"></script>

<!-- GeoFire -->
<script src="https://cdn.firebase.com/libs/geofire/5.0.1/geofire.min.js"></script>
```

And when we create a GeoFire instance in the JavaScript:

```JavaScript
// Create a new GeoFire instance at the random Firebase location
var geoFireInstance = new geofire.GeoFire(firebaseRef);
```