### PR TITLE
Fix unbound 'this' in setTimeout function

### DIFF
--- a/src/GeoQuery.ts
+++ b/src/GeoQuery.ts
@@ -396,7 +396,9 @@ export class GeoQuery {
     // kick off a timeout to clean them up so we don't create an infinite number of unneeded queries.
     if (this._geohashCleanupScheduled === false && Object.keys(this._currentGeohashesQueried).length > 25) {
       this._geohashCleanupScheduled = true;
-      this._cleanUpCurrentGeohashesQueriedTimeout = setTimeout(this._cleanUpCurrentGeohashesQueried, 10);
+      this._cleanUpCurrentGeohashesQueriedTimeout = setTimeout(() => {
+        this._cleanUpCurrentGeohashesQueried();
+      }, 10);
     }
 
     // Keep track of which geohashes have been processed so we know when to fire the 'ready' event


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description
Fixed a trivial bug of an unbound `this` in `setTimeout` call, by wrapping the function argument with an arrow function.

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->


<!-- Proposing an API change? Provide code samples showing how the API will be used. -->
