### PR TITLE
Migrate to firebase v9 modular sdk

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 8.x
+          - 10.x
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,3 @@
-
+- [Breaking change] Upgraded GeoFire to use the Firebase JS SDK v9. GeoFire no longer supports Firebase SDK below version 9.0.0
+- [Internal] Replace the `uglify` plugin with `terser`
+- See the migration guide (https://github.com/firebase/geofire-js/tree/master/migration#upgrading-from-geofire-3xx-to-4xx) for upgrade instructions

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -3,6 +3,45 @@
 Below are instructions for migrating from one version of GeoFire to another. If you are upgrading
 several versions at once, make sure you follow the migration instructions for all upgrades.
 
+## `5.x.x` to `6.x.x`
+
+With the release of GeoFire `6.0.0`, GeoFire now uses the new
+[Firebase Modular SDK](https://firebase.blog/posts/2021/07/introducing-the-new-firebase-js-sdk#introducing-firestore-lite).
+
+This only changes the way you interact with the Firebase SDK, but not how you interact with GeoFire.
+
+For example, this:
+```js
+// Initialize the Firebase SDK
+firebase.initializeApp({
+  // ...
+});
+
+// Create a Firebase reference where GeoFire will store its information
+var firebaseRef = firebase.database().ref();
+
+// Create a GeoFire index
+var geoFire = new GeoFire(firebaseRef);
+```
+
+Becomes:
+```js
+import { initializeApp } from 'firebase/app';
+import { getDatabase, ref } from "firebase/database";
+
+// Initialize the Firebase SDK
+initializeApp({
+  // ...
+});
+
+// Create a Firebase reference where GeoFire will store its information
+var firebaseRef = ref(getDatabase());
+
+// Create a GeoFire index
+var geoFire = new GeoFire(firebaseRef);
+```
+
+See [Firebase's upgrade guide](https://firebase.google.com/docs/web/modular-upgrade) for more details.
 
 ## `3.x.x` to `4.x.x`
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -6,9 +6,9 @@ several versions at once, make sure you follow the migration instructions for al
 ## `5.x.x` to `6.x.x`
 
 With the release of GeoFire `6.0.0`, GeoFire now uses the new
-[Firebase Modular SDK](https://firebase.blog/posts/2021/07/introducing-the-new-firebase-js-sdk#introducing-firestore-lite).
+[Firebase Modular SDK](https://firebase.blog/posts/2021/07/introducing-the-new-firebase-js-sdk#introducing-firestore-lite). This new SDK is incompatible with previous versions, so if you're still using an older version of the Firebase SDK or our [compat module](https://firebase.google.com/docs/web/modular-upgrade#update_imports_to_v9_compat), please stick to version `5.x.x` of GeoFire.
 
-This only changes the way you interact with the Firebase SDK, but not how you interact with GeoFire.
+This change only affects the way you interact with the Firebase SDK, but not how you interact with GeoFire.
 
 For example, this:
 ```js

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -32,13 +32,16 @@ Creates and returns a new `GeoFire` instance to manage your location data. Data 
 the location pointed to by `firebaseRef`. Note that this `firebaseRef` can point to anywhere in your Firebase database.
 
 ```JavaScript
+import { initializeApp } from 'firebase/app';
+import { getDatabase, ref } from "firebase/database";
+
 // Initialize the Firebase SDK
-firebase.initializeApp({
+initializeApp({
   // ...
 });
 
 // Create a Firebase reference where GeoFire will store its information
-var firebaseRef = firebase.database().ref();
+var firebaseRef = ref(getDatabase());
 
 // Create a GeoFire index
 var geoFire = new GeoFire(firebaseRef);
@@ -49,7 +52,9 @@ var geoFire = new GeoFire(firebaseRef);
 Returns the `Firebase` reference used to create this `GeoFire` instance.
 
 ```JavaScript
-var firebaseRef = firebase.database().ref();
+import { getDatabase, ref } from "firebase/database";
+
+var firebaseRef = ref(getDatabase());
 var geoFire = new GeoFire(firebaseRef);
 
 var ref = geoFire.ref();  // ref === firebaseRef

--- a/examples/fish1/index.html
+++ b/examples/fish1/index.html
@@ -4,14 +4,16 @@
     <title>GeoFire fish1 Example</title>
 
     <!-- Firebase -->
-    <script src="https://www.gstatic.com/firebasejs/5.9.4/firebase-app.js"></script>
-    <script src="https://www.gstatic.com/firebasejs/5.9.4/firebase-database.js"></script>
+    <script type="module">
+      import { initializeApp } from 'https://www.gstatic.com/firebasejs/9.8.4/firebase-app.js'
+      import { getDatabase, ref, push } from 'https://www.gstatic.com/firebasejs/9.8.4/firebase-database.js'
+    </script>
 
     <!-- RSVP -->
     <script src="https://unpkg.com/rsvp@3.1.0/dist/rsvp.min.js"></script>
 
     <!-- GeoFire -->
-    <script src="https://cdn.firebase.com/libs/geofire/5.0.1/geofire.min.js"></script>
+    <script src="https://cdn.firebase.com/libs/geofire/6.0.0/geofire.min.js"></script>
 
     <!-- Custom JS -->
     <script src="js/fish1.js" defer></script>

--- a/examples/fish1/js/fish1.js
+++ b/examples/fish1/js/fish1.js
@@ -1,13 +1,13 @@
 (function() {
   // Initialize the Firebase SDK
-  firebase.initializeApp({
+  initializeApp({
     apiKey: "AIzaSyCR4ND2xwX3kU1IxTn0youF5OlI3x6MFZs",
     databaseURL: "https://geofire-gh-tests.firebaseio.com",
     projectId: "geofire-gh-tests"
   });
 
   // Generate a random Firebase location
-  var firebaseRef = firebase.database().ref().push();
+  var firebaseRef = push(ref(getDatabase()));
 
   // Create a new GeoFire instance at the random Firebase location
   var geoFireInstance = new geofire.GeoFire(firebaseRef);

--- a/examples/fish2/index.html
+++ b/examples/fish2/index.html
@@ -4,14 +4,16 @@
     <title>GeoFire fish2 Example</title>
 
     <!-- Firebase -->
-    <script src="https://www.gstatic.com/firebasejs/5.9.4/firebase-app.js"></script>
-    <script src="https://www.gstatic.com/firebasejs/5.9.4/firebase-database.js"></script>
+    <script type="module">
+      import { initializeApp } from 'https://www.gstatic.com/firebasejs/9.8.4/firebase-app.js'
+      import { getDatabase, ref, push } from 'https://www.gstatic.com/firebasejs/9.8.4/firebase-database.js'
+    </script>
 
     <!-- RSVP -->
     <script src="https://unpkg.com/rsvp@3.1.0/dist/rsvp.min.js"></script>
 
     <!-- GeoFire -->
-    <script src="https://cdn.firebase.com/libs/geofire/5.0.1/geofire.min.js"></script>
+    <script src="https://cdn.firebase.com/libs/geofire/6.0.0/geofire.min.js"></script>
 
     <!-- Custom JS -->
     <script src="js/fish2.js" defer></script>

--- a/examples/fish2/js/fish2.js
+++ b/examples/fish2/js/fish2.js
@@ -1,13 +1,13 @@
 (function() {
   // Initialize the Firebase SDK
-  firebase.initializeApp({
+  initializeApp({
     apiKey: "sAIzaSyCR4ND2xwX3kU1IxTn0youF5OlI3x6MFZs",
     databaseURL: "https://geofire-gh-tests.firebaseio.com",
     projectId: "geofire-gh-tests"
   });
 
   // Generate a random Firebase location
-  var firebaseRef = firebase.database().ref().push();
+  var firebaseRef = push(ref(getDatabase()));
 
   // Create a new GeoFire instance at the random Firebase location
   var geoFireInstance = new geofire.GeoFire(firebaseRef);

--- a/examples/fish3/index.html
+++ b/examples/fish3/index.html
@@ -4,14 +4,16 @@
     <title>GeoFire fish3 Example</title>
 
     <!-- Firebase -->
-    <script src="https://www.gstatic.com/firebasejs/5.9.4/firebase-app.js"></script>
-    <script src="https://www.gstatic.com/firebasejs/5.9.4/firebase-database.js"></script>
+    <script type="module">
+      import { initializeApp } from 'https://www.gstatic.com/firebasejs/9.8.4/firebase-app.js'
+      import { getDatabase, ref, push } from 'https://www.gstatic.com/firebasejs/9.8.4/firebase-database.js'
+    </script>
 
     <!-- RSVP -->
     <script src="https://unpkg.com/rsvp@3.1.0/dist/rsvp.min.js"></script>
 
     <!-- GeoFire -->
-    <script src="https://cdn.firebase.com/libs/geofire/5.0.1/geofire.min.js"></script>
+    <script src="https://cdn.firebase.com/libs/geofire/6.0.0/geofire.min.js"></script>
 
     <!-- Custom JS -->
     <script src="js/fish3.js" defer></script>

--- a/examples/fish3/js/fish3.js
+++ b/examples/fish3/js/fish3.js
@@ -1,13 +1,13 @@
 (function() {
   // Initialize the Firebase SDK
-  firebase.initializeApp({
+  initializeApp({
     apiKey: "AIzaSyCR4ND2xwX3kU1IxTn0youF5OlI3x6MFZs",
     databaseURL: "https://geofire-gh-tests.firebaseio.com",
     projectId: "geofire-gh-tests"
   });
 
   // Generate a random Firebase location
-  var firebaseRef = firebase.database().ref().push();
+  var firebaseRef = push(ref(getDatabase()));
 
   // Create a new GeoFire instance at the random Firebase location
   var geoFireInstance = new geofire.GeoFire(firebaseRef);

--- a/examples/html5Geolocation/index.html
+++ b/examples/html5Geolocation/index.html
@@ -4,11 +4,13 @@
     <title>GeoFire HTML5 Geolocation API Example</title>
 
     <!-- Firebase -->
-    <script src="https://www.gstatic.com/firebasejs/5.9.4/firebase-app.js"></script>
-    <script src="https://www.gstatic.com/firebasejs/5.9.4/firebase-database.js"></script>
+    <script type="module">
+      import { initializeApp } from 'https://www.gstatic.com/firebasejs/9.8.4/firebase-app.js'
+      import { getDatabase, ref, push } from 'https://www.gstatic.com/firebasejs/9.8.4/firebase-database.js'
+    </script>
 
     <!-- GeoFire -->
-    <script src="https://cdn.firebase.com/libs/geofire/5.0.1/geofire.min.js"></script>
+    <script src="https://cdn.firebase.com/libs/geofire/6.0.0/geofire.min.js"></script>
 
     <!-- Custom JS -->
     <script src="js/html5Geolocation.js" defer></script>

--- a/examples/html5Geolocation/js/html5Geolocation.js
+++ b/examples/html5Geolocation/js/html5Geolocation.js
@@ -1,13 +1,13 @@
 (function() {
   // Initialize the Firebase SDK
-  firebase.initializeApp({
+  initializeApp({
     apiKey: "AIzaSyCR4ND2xwX3kU1IxTn0youF5OlI3x6MFZs",
     databaseURL: "https://geofire-gh-tests.firebaseio.com",
     projectId: "geofire-gh-tests"
   });
 
   // Generate a random Firebase location
-  var firebaseRef = firebase.database().ref().push();
+  var firebaseRef = push(ref(getDatabase()));
 
   // Create a new GeoFire instance at the random Firebase location
   var geoFireInstance = new geofire.GeoFire(firebaseRef);

--- a/examples/queryBuilder/index.html
+++ b/examples/queryBuilder/index.html
@@ -7,11 +7,13 @@
     <script src="https://code.jquery.com/jquery-2.2.1.min.js"></script>
 
     <!-- Firebase -->
-    <script src="https://www.gstatic.com/firebasejs/5.9.4/firebase-app.js"></script>
-    <script src="https://www.gstatic.com/firebasejs/5.9.4/firebase-database.js"></script>
+    <script type="module">
+      import { initializeApp } from 'https://www.gstatic.com/firebasejs/9.8.4/firebase-app.js'
+      import { getDatabase, ref, push } from 'https://www.gstatic.com/firebasejs/9.8.4/firebase-database.js'
+    </script>
 
     <!-- GeoFire -->
-    <script src="https://cdn.firebase.com/libs/geofire/5.0.1/geofire.min.js"></script>
+    <script src="https://cdn.firebase.com/libs/geofire/6.0.0/geofire.min.js"></script>
 
     <!-- Custom JS -->
     <script src="js/queryBuilder.js" defer></script>

--- a/examples/queryBuilder/js/queryBuilder.js
+++ b/examples/queryBuilder/js/queryBuilder.js
@@ -1,13 +1,13 @@
 (function() {
   // Initialize the Firebase SDK
-  firebase.initializeApp({
+  initializeApp({
     apiKey: "AIzaSyCR4ND2xwX3kU1IxTn0youF5OlI3x6MFZs",
     databaseURL: "https://geofire-gh-tests.firebaseio.com",
     projectId: "geofire-gh-tests"
   });
 
   // Generate a random Firebase location
-  var firebaseRef = firebase.database().ref().push();
+  var firebaseRef = push(ref(getDatabase()));
 
   // Create a new GeoFire instance at the random Firebase location
   var geoFireInstance = new geofire.GeoFire(firebaseRef);

--- a/packages/geofire-common/package-lock.json
+++ b/packages/geofire-common/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "geofire-common",
-	"version": "5.0.1",
+	"version": "5.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -140,222 +140,6 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
-		"@firebase/app": {
-			"version": "0.3.17",
-			"resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.3.17.tgz",
-			"integrity": "sha512-/8lDeeIxgdCIMffrfBPQ3bcdSkF8bx4KCp8pKMPOG/HYKoeM8I9eP4zlzxL5ABzRjvcdhK9KOYOn0jRrNrGD9g==",
-			"dev": true,
-			"requires": {
-				"@firebase/app-types": "0.3.10",
-				"@firebase/util": "0.2.14",
-				"dom-storage": "2.1.0",
-				"tslib": "1.9.3",
-				"xmlhttprequest": "1.8.0"
-			},
-			"dependencies": {
-				"@firebase/app-types": {
-					"version": "0.3.10",
-					"resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.3.10.tgz",
-					"integrity": "sha512-l+5BJtSQopalBXiY/YuSaB9KF9PnDj37FLV0Sx3qJjh5B3IthCuZbPc1Vpbbbee/QZgudl0G212BBsUMGHP+fQ==",
-					"dev": true
-				}
-			}
-		},
-		"@firebase/app-types": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.6.1.tgz",
-			"integrity": "sha512-L/ZnJRAq7F++utfuoTKX4CLBG5YR7tFO3PLzG1/oXXKEezJ0kRL3CMRoueBEmTCzVb/6SIs2Qlaw++uDgi5Xyg=="
-		},
-		"@firebase/auth": {
-			"version": "0.10.2",
-			"resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.10.2.tgz",
-			"integrity": "sha512-+S8RZcHhhat2xrW/RGOcSZO8pv0qHveaw09Bq/gXhZyJfN86UeiMc3sv4YMo1Hu7fRRorNteijpmlH522eI0AA==",
-			"dev": true,
-			"requires": {
-				"@firebase/auth-types": "0.6.1"
-			}
-		},
-		"@firebase/auth-types": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.6.1.tgz",
-			"integrity": "sha512-uciPeIQJC1NZDhI5+BWbyqi70YXIjT3jm03sYtIgkPt2sr3n8sq1RpnoTMYfAJkQ0QlgLaBkeM/huMx06eBoXQ==",
-			"dev": true
-		},
-		"@firebase/database": {
-			"version": "0.3.20",
-			"resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.3.20.tgz",
-			"integrity": "sha512-fZHRIlRQlND/UrzI1beUTRKfktjMvMEiUOar6ylFZqOj2KNVO4CrF95UGqRl0HBGhZzlBKzaDYAcJze2D6C4+Q==",
-			"dev": true,
-			"requires": {
-				"@firebase/database-types": "0.3.11",
-				"@firebase/logger": "0.1.13",
-				"@firebase/util": "0.2.14",
-				"faye-websocket": "0.11.1",
-				"tslib": "1.9.3"
-			},
-			"dependencies": {
-				"@firebase/database-types": {
-					"version": "0.3.11",
-					"resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.3.11.tgz",
-					"integrity": "sha512-iRAZzs7Zlmmvh7r0XlR1MAO6I6bm1HjW9m1ytfJ6E/8+zItHnbVH4iiVVkC39r1wMGrtPMz8FiIUWoaasPF5dA==",
-					"dev": true
-				}
-			}
-		},
-		"@firebase/database-types": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.5.2.tgz",
-			"integrity": "sha512-ap2WQOS3LKmGuVFKUghFft7RxXTyZTDr0Xd8y2aqmWsbJVjgozi0huL/EUMgTjGFrATAjcf2A7aNs8AKKZ2a8g==",
-			"requires": {
-				"@firebase/app-types": "0.6.1"
-			}
-		},
-		"@firebase/firestore": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-1.2.2.tgz",
-			"integrity": "sha512-5o3SFTpMYaWrWRlm5qBX84fNDwdiPTbb0qo6KDI+OvIzTaMsEfOJ4vUz+Binxfq0dPen0fU6JLO+xix8Sa8TBA==",
-			"dev": true,
-			"requires": {
-				"@firebase/firestore-types": "1.2.1",
-				"@firebase/logger": "0.1.13",
-				"@firebase/webchannel-wrapper": "0.2.19",
-				"grpc": "1.20.0",
-				"tslib": "1.9.3"
-			}
-		},
-		"@firebase/firestore-types": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-1.2.1.tgz",
-			"integrity": "sha512-/Klu3uVLoTjW3ckYqFTV3lr9HzEKM7pMpPHao1Sy+YwIUmTjFMI1LE2WcXMx6HN2jipFjjD/Xjg0hY0+0dnPCg==",
-			"dev": true
-		},
-		"@firebase/functions": {
-			"version": "0.4.6",
-			"resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.4.6.tgz",
-			"integrity": "sha512-jpRLY8GyhmFufnN3eilvIuAqD9qsG2/AftGtFaTRL0ObSySmraYcVOpKAxsFZW//9EMNtI9c9/rw+QFq5SkuyA==",
-			"dev": true,
-			"requires": {
-				"@firebase/functions-types": "0.3.5",
-				"@firebase/messaging-types": "0.2.11",
-				"isomorphic-fetch": "2.2.1",
-				"tslib": "1.9.3"
-			}
-		},
-		"@firebase/functions-types": {
-			"version": "0.3.5",
-			"resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.3.5.tgz",
-			"integrity": "sha512-3hTMqfSugCfxzT6vZPbzQ58G4941rsFr99fWKXGKFAl2QpdMBCnKmEKdg/p5M47xIPyzIQn6NMF5kCo/eICXhA==",
-			"dev": true
-		},
-		"@firebase/installations": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.1.0.tgz",
-			"integrity": "sha512-drt9kDT4w/OCXt5nboOIaUGI3lDwHAoSY2V6qJTbtbd3qVSxE0EBLA4c+allpWdmrhGBrASApuA0eAjphxuXIw==",
-			"dev": true,
-			"requires": {
-				"@firebase/installations-types": "0.1.0",
-				"@firebase/util": "0.2.14",
-				"idb": "3.0.2"
-			}
-		},
-		"@firebase/installations-types": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.1.0.tgz",
-			"integrity": "sha512-cw2UIvPa3+umy6w7dGj0LqQQ9v7WEOro5s+6B+v54Tw25WyLnR6cBIkyyahv3Uu9QPnGZCIsemlQwxIaIOMb9g==",
-			"dev": true
-		},
-		"@firebase/logger": {
-			"version": "0.1.13",
-			"resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.1.13.tgz",
-			"integrity": "sha512-wIbLwQ2oJCkvHIE7J3FDxpScKY84fSctEEjOi0PB+Yn2dN8AwqtM7YF8rtcY8cxntv8dyR+i7GNg1Nd89cGxkA==",
-			"dev": true
-		},
-		"@firebase/messaging": {
-			"version": "0.3.19",
-			"resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.3.19.tgz",
-			"integrity": "sha512-xY1Hlsj0MqyU/AmJQLyH9Uknhs8+1OsD2xXE8W34qk0g2RtpygUN7JMD21d5w5zZ5dMtLNhVSIxU8oI2rAUjcA==",
-			"dev": true,
-			"requires": {
-				"@firebase/messaging-types": "0.2.11",
-				"@firebase/util": "0.2.14",
-				"tslib": "1.9.3"
-			}
-		},
-		"@firebase/messaging-types": {
-			"version": "0.2.11",
-			"resolved": "https://registry.npmjs.org/@firebase/messaging-types/-/messaging-types-0.2.11.tgz",
-			"integrity": "sha512-uWtzPMj1mAX8EbG68SnxE12Waz+hRuO7vtosUFePGBfxVNNmPx5vJyKZTz+hbM4P77XddshAiaEkyduro4gNgA==",
-			"dev": true
-		},
-		"@firebase/performance": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.2.1.tgz",
-			"integrity": "sha512-vo/24+W35foc2ShRgeIlx2Ej45+Sn6uYPpnYzTtJb3DwE3sb0BVGocVgINbXyguUq2PHS+6yLsCm88y12DS2EA==",
-			"dev": true,
-			"requires": {
-				"@firebase/installations": "0.1.0",
-				"@firebase/logger": "0.1.13",
-				"@firebase/performance-types": "0.0.1",
-				"@firebase/util": "0.2.14",
-				"tslib": "1.9.3"
-			}
-		},
-		"@firebase/performance-types": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.0.1.tgz",
-			"integrity": "sha512-U45GbVAnPyz7wPLd3FrWdTeaFSvgsnGfGK58VojfEMmFnMAixCM3qBv1XJ0xfhyKbK1xZN4+usWAR8F3CwRAXw==",
-			"dev": true
-		},
-		"@firebase/polyfill": {
-			"version": "0.3.13",
-			"resolved": "https://registry.npmjs.org/@firebase/polyfill/-/polyfill-0.3.13.tgz",
-			"integrity": "sha512-nmz0KMrGZh4wvy8iPnOCtpSXw0LwXPdj9lqgeOVClXMgJBi5+FS1q0W1Ofn7BULmMc8tYsGGY+T2HvfmznMuPg==",
-			"dev": true,
-			"requires": {
-				"core-js": "3.0.1",
-				"promise-polyfill": "8.1.0",
-				"whatwg-fetch": "2.0.4"
-			},
-			"dependencies": {
-				"whatwg-fetch": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-					"integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
-					"dev": true
-				}
-			}
-		},
-		"@firebase/storage": {
-			"version": "0.2.15",
-			"resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.2.15.tgz",
-			"integrity": "sha512-WR80AXm1btlHERavhSwiTwFAyT/M/Jn6/2I3RAlcVOS6NnKVdRIcSVW1zY9jvO3fdeksqBU9NKTXeXFTmsrw6g==",
-			"dev": true,
-			"requires": {
-				"@firebase/storage-types": "0.2.11",
-				"tslib": "1.9.3"
-			}
-		},
-		"@firebase/storage-types": {
-			"version": "0.2.11",
-			"resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.2.11.tgz",
-			"integrity": "sha512-vGTFJmKbfScmCAVUamREIBTopr5Uusxd8xPAgNDxMZwICvdCjHO0UH0pZZj6iBQuwxLe/NEtFycPnu1kKT+TPw==",
-			"dev": true
-		},
-		"@firebase/util": {
-			"version": "0.2.14",
-			"resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.2.14.tgz",
-			"integrity": "sha512-2ke1Lra0R5T+5ucCMWft/IB2rI/IzumHHYm9aqrM9lJ3XURiWmBHAYrvaPVP7///gDhJAo+NNDUCAJH/Y4PmvA==",
-			"dev": true,
-			"requires": {
-				"tslib": "1.9.3"
-			}
-		},
-		"@firebase/webchannel-wrapper": {
-			"version": "0.2.19",
-			"resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.2.19.tgz",
-			"integrity": "sha512-U9e2dCB38mD2AvV/zAjghauwa0UX15Wt98iBgm8IOw8spluDxysx8UZFUhj38fu0iFXORVRBqseyK2wCxZIl5w==",
-			"dev": true
-		},
 		"@types/chai": {
 			"version": "4.2.12",
 			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.12.tgz",
@@ -429,12 +213,6 @@
 				"uri-js": "^4.2.2"
 			}
 		},
-		"ansi-regex": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-			"dev": true
-		},
 		"ansi-styles": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -485,16 +263,6 @@
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
 			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
 			"dev": true
-		},
-		"ascli": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/ascli/-/ascli-1.0.1.tgz",
-			"integrity": "sha1-vPpZdKYvGOgcq660lzKrSoj5Brw=",
-			"dev": true,
-			"requires": {
-				"colour": "~0.7.1",
-				"optjs": "~3.2.2"
-			}
 		},
 		"asn1": {
 			"version": "0.2.4",
@@ -601,21 +369,6 @@
 			"integrity": "sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==",
 			"dev": true
 		},
-		"bytebuffer": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/bytebuffer/-/bytebuffer-5.0.1.tgz",
-			"integrity": "sha1-WC7qSxqHO20CCkjVjfhfC7ps/d0=",
-			"dev": true,
-			"requires": {
-				"long": "~3"
-			}
-		},
-		"camelcase": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-			"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-			"dev": true
-		},
 		"caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -653,23 +406,6 @@
 			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
 			"dev": true
 		},
-		"cliui": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-			"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-			"dev": true,
-			"requires": {
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1",
-				"wrap-ansi": "^2.0.0"
-			}
-		},
-		"code-point-at": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-			"dev": true
-		},
 		"color-convert": {
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -683,12 +419,6 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-			"dev": true
-		},
-		"colour": {
-			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/colour/-/colour-0.7.1.tgz",
-			"integrity": "sha1-nLFpkX7F0SwHNtPoaFdG3xyt93g=",
 			"dev": true
 		},
 		"combined-stream": {
@@ -710,12 +440,6 @@
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"dev": true
-		},
-		"core-js": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.0.1.tgz",
-			"integrity": "sha512-sco40rF+2KlE0ROMvydjkrVMMG1vYilP2ALoRXcYR4obqbYIuV3Bg+51GEDW+HF8n7NRA+iaA4qD0nD9lo9mew==",
 			"dev": true
 		},
 		"core-util-is": {
@@ -781,12 +505,6 @@
 				"ms": "2.0.0"
 			}
 		},
-		"decamelize": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-			"dev": true
-		},
 		"deep-eql": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
@@ -814,12 +532,6 @@
 			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
 			"dev": true
 		},
-		"dom-storage": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/dom-storage/-/dom-storage-2.1.0.tgz",
-			"integrity": "sha512-g6RpyWXzl0RR6OTElHKBl7nwnK87GUyZMYC7JWsB/IA73vpqK2K6LT39x4VepLxlSsWBFrPVLnsSR5Jyty0+2Q==",
-			"dev": true
-		},
 		"domexception": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
@@ -837,15 +549,6 @@
 			"requires": {
 				"jsbn": "~0.1.0",
 				"safer-buffer": "^2.1.0"
-			}
-		},
-		"encoding": {
-			"version": "0.1.13",
-			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-			"integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-			"dev": true,
-			"requires": {
-				"iconv-lite": "^0.6.2"
 			}
 		},
 		"escape-string-regexp": {
@@ -948,15 +651,6 @@
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
 			"dev": true
 		},
-		"faye-websocket": {
-			"version": "0.11.1",
-			"resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
-			"integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
-			"dev": true,
-			"requires": {
-				"websocket-driver": ">=0.5.1"
-			}
-		},
 		"filename-regex": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
@@ -974,23 +668,6 @@
 				"randomatic": "^3.0.0",
 				"repeat-element": "^1.1.2",
 				"repeat-string": "^1.5.2"
-			}
-		},
-		"firebase": {
-			"version": "5.11.1",
-			"resolved": "https://registry.npmjs.org/firebase/-/firebase-5.11.1.tgz",
-			"integrity": "sha512-cop2UHytKas8WJZTovZqhpZIgwRfsvegijyOjgmMJoaOHCnyH4eymPneglgXsK5ExOdxJSTC4QD5qETrdL3dMw==",
-			"dev": true,
-			"requires": {
-				"@firebase/app": "0.3.17",
-				"@firebase/auth": "0.10.2",
-				"@firebase/database": "0.3.20",
-				"@firebase/firestore": "1.2.2",
-				"@firebase/functions": "0.4.6",
-				"@firebase/messaging": "0.3.19",
-				"@firebase/performance": "0.2.1",
-				"@firebase/polyfill": "0.3.13",
-				"@firebase/storage": "0.2.15"
 			}
 		},
 		"for-in": {
@@ -1108,490 +785,6 @@
 			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
 			"dev": true
 		},
-		"grpc": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/grpc/-/grpc-1.20.0.tgz",
-			"integrity": "sha512-HgYuJzRomkBlJAfC/78epuWzwMiByxgj4JsO6G6dHXXNfARTsUqpM/FmPSJJNFGvzCev0g6tn33CE7nWEmhDEg==",
-			"dev": true,
-			"requires": {
-				"lodash.camelcase": "^4.3.0",
-				"lodash.clone": "^4.5.0",
-				"nan": "^2.0.0",
-				"node-pre-gyp": "^0.12.0",
-				"protobufjs": "^5.0.3"
-			},
-			"dependencies": {
-				"abbrev": {
-					"version": "1.1.1",
-					"bundled": true,
-					"dev": true
-				},
-				"ansi-regex": {
-					"version": "2.1.1",
-					"bundled": true,
-					"dev": true
-				},
-				"aproba": {
-					"version": "1.2.0",
-					"bundled": true,
-					"dev": true
-				},
-				"are-we-there-yet": {
-					"version": "1.1.5",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"delegates": "^1.0.0",
-						"readable-stream": "^2.0.6"
-					}
-				},
-				"balanced-match": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"brace-expansion": {
-					"version": "1.1.11",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"balanced-match": "^1.0.0",
-						"concat-map": "0.0.1"
-					}
-				},
-				"chownr": {
-					"version": "1.1.1",
-					"bundled": true,
-					"dev": true
-				},
-				"code-point-at": {
-					"version": "1.1.0",
-					"bundled": true,
-					"dev": true
-				},
-				"concat-map": {
-					"version": "0.0.1",
-					"bundled": true,
-					"dev": true
-				},
-				"console-control-strings": {
-					"version": "1.1.0",
-					"bundled": true,
-					"dev": true
-				},
-				"core-util-is": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
-				},
-				"debug": {
-					"version": "2.6.9",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"deep-extend": {
-					"version": "0.6.0",
-					"bundled": true,
-					"dev": true
-				},
-				"delegates": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"detect-libc": {
-					"version": "1.0.3",
-					"bundled": true,
-					"dev": true
-				},
-				"fs-minipass": {
-					"version": "1.2.5",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"minipass": "^2.2.1"
-					}
-				},
-				"fs.realpath": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"gauge": {
-					"version": "2.7.4",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"aproba": "^1.0.3",
-						"console-control-strings": "^1.0.0",
-						"has-unicode": "^2.0.0",
-						"object-assign": "^4.1.0",
-						"signal-exit": "^3.0.0",
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wide-align": "^1.1.0"
-					}
-				},
-				"glob": {
-					"version": "7.1.2",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"has-unicode": {
-					"version": "2.0.1",
-					"bundled": true,
-					"dev": true
-				},
-				"iconv-lite": {
-					"version": "0.4.23",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"safer-buffer": ">= 2.1.2 < 3"
-					}
-				},
-				"ignore-walk": {
-					"version": "3.0.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"minimatch": "^3.0.4"
-					}
-				},
-				"inflight": {
-					"version": "1.0.6",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"once": "^1.3.0",
-						"wrappy": "1"
-					}
-				},
-				"inherits": {
-					"version": "2.0.3",
-					"bundled": true,
-					"dev": true
-				},
-				"ini": {
-					"version": "1.3.5",
-					"bundled": true,
-					"dev": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"minimatch": {
-					"version": "3.0.4",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"brace-expansion": "^1.1.7"
-					}
-				},
-				"minimist": {
-					"version": "1.2.0",
-					"bundled": true,
-					"dev": true
-				},
-				"minipass": {
-					"version": "2.3.5",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"safe-buffer": "^5.1.2",
-						"yallist": "^3.0.0"
-					}
-				},
-				"minizlib": {
-					"version": "1.1.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"minipass": "^2.2.1"
-					}
-				},
-				"mkdirp": {
-					"version": "0.5.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"minimist": "0.0.8"
-					},
-					"dependencies": {
-						"minimist": {
-							"version": "0.0.8",
-							"bundled": true,
-							"dev": true
-						}
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"needle": {
-					"version": "2.2.4",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"debug": "^2.1.2",
-						"iconv-lite": "^0.4.4",
-						"sax": "^1.2.4"
-					}
-				},
-				"node-pre-gyp": {
-					"version": "0.12.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"detect-libc": "^1.0.2",
-						"mkdirp": "^0.5.1",
-						"needle": "^2.2.1",
-						"nopt": "^4.0.1",
-						"npm-packlist": "^1.1.6",
-						"npmlog": "^4.0.2",
-						"rc": "^1.2.7",
-						"rimraf": "^2.6.1",
-						"semver": "^5.3.0",
-						"tar": "^4"
-					}
-				},
-				"nopt": {
-					"version": "4.0.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"abbrev": "1",
-						"osenv": "^0.1.4"
-					}
-				},
-				"npm-bundled": {
-					"version": "1.0.5",
-					"bundled": true,
-					"dev": true
-				},
-				"npm-packlist": {
-					"version": "1.1.12",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"ignore-walk": "^3.0.1",
-						"npm-bundled": "^1.0.1"
-					}
-				},
-				"npmlog": {
-					"version": "4.1.2",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"are-we-there-yet": "~1.1.2",
-						"console-control-strings": "~1.1.0",
-						"gauge": "~2.7.3",
-						"set-blocking": "~2.0.0"
-					}
-				},
-				"number-is-nan": {
-					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
-				},
-				"object-assign": {
-					"version": "4.1.1",
-					"bundled": true,
-					"dev": true
-				},
-				"once": {
-					"version": "1.4.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"wrappy": "1"
-					}
-				},
-				"os-homedir": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
-				},
-				"os-tmpdir": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
-				},
-				"osenv": {
-					"version": "0.1.5",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"os-homedir": "^1.0.0",
-						"os-tmpdir": "^1.0.0"
-					}
-				},
-				"path-is-absolute": {
-					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
-				},
-				"process-nextick-args": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"rc": {
-					"version": "1.2.8",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"deep-extend": "^0.6.0",
-						"ini": "~1.3.0",
-						"minimist": "^1.2.0",
-						"strip-json-comments": "~2.0.1"
-					}
-				},
-				"readable-stream": {
-					"version": "2.3.6",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"rimraf": {
-					"version": "2.6.2",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"glob": "^7.0.5"
-					}
-				},
-				"safe-buffer": {
-					"version": "5.1.2",
-					"bundled": true,
-					"dev": true
-				},
-				"safer-buffer": {
-					"version": "2.1.2",
-					"bundled": true,
-					"dev": true
-				},
-				"sax": {
-					"version": "1.2.4",
-					"bundled": true,
-					"dev": true
-				},
-				"semver": {
-					"version": "5.6.0",
-					"bundled": true,
-					"dev": true
-				},
-				"set-blocking": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"signal-exit": {
-					"version": "3.0.2",
-					"bundled": true,
-					"dev": true
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"strip-json-comments": {
-					"version": "2.0.1",
-					"bundled": true,
-					"dev": true
-				},
-				"tar": {
-					"version": "4.4.8",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"chownr": "^1.1.1",
-						"fs-minipass": "^1.2.5",
-						"minipass": "^2.3.4",
-						"minizlib": "^1.1.1",
-						"mkdirp": "^0.5.0",
-						"safe-buffer": "^5.1.2",
-						"yallist": "^3.0.2"
-					}
-				},
-				"util-deprecate": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
-				},
-				"wide-align": {
-					"version": "1.1.3",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"string-width": "^1.0.2 || 2"
-					}
-				},
-				"wrappy": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
-				},
-				"yallist": {
-					"version": "3.0.3",
-					"bundled": true,
-					"dev": true
-				}
-			}
-		},
 		"har-schema": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -1629,12 +822,6 @@
 				"whatwg-encoding": "^1.0.1"
 			}
 		},
-		"http-parser-js": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.2.tgz",
-			"integrity": "sha512-opCO9ASqg5Wy2FNo7A0sxy71yGbbkJJXLdgMK04Tcypw9jr2MgWbyubb0+WdmDmGnFflO7fRbqbaihh/ENDlRQ==",
-			"dev": true
-		},
 		"http-signature": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -1645,21 +832,6 @@
 				"jsprim": "^1.2.2",
 				"sshpk": "^1.7.0"
 			}
-		},
-		"iconv-lite": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
-			"integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
-			"dev": true,
-			"requires": {
-				"safer-buffer": ">= 2.1.2 < 3.0.0"
-			}
-		},
-		"idb": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/idb/-/idb-3.0.2.tgz",
-			"integrity": "sha512-+FLa/0sTXqyux0o6C+i2lOR0VoS60LU/jzUo5xjfY6+7sEEgy4Gz1O7yFBXvjd7N0NyIGWIRg8DcQSLEG+VSPw==",
-			"dev": true
 		},
 		"inflight": {
 			"version": "1.0.6",
@@ -1675,12 +847,6 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
-		},
-		"invert-kv": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
 			"dev": true
 		},
 		"is-buffer": {
@@ -1715,15 +881,6 @@
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
 			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
 			"dev": true
-		},
-		"is-fullwidth-code-point": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-			"dev": true,
-			"requires": {
-				"number-is-nan": "^1.0.0"
-			}
 		},
 		"is-glob": {
 			"version": "2.0.1",
@@ -1761,12 +918,6 @@
 			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
 			"dev": true
 		},
-		"is-stream": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-			"dev": true
-		},
 		"is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -1786,16 +937,6 @@
 			"dev": true,
 			"requires": {
 				"isarray": "1.0.0"
-			}
-		},
-		"isomorphic-fetch": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-			"dev": true,
-			"requires": {
-				"node-fetch": "^1.0.1",
-				"whatwg-fetch": ">=0.10.0"
 			}
 		},
 		"isstream": {
@@ -1962,15 +1103,6 @@
 				"is-buffer": "^1.1.5"
 			}
 		},
-		"lcid": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-			"dev": true,
-			"requires": {
-				"invert-kv": "^1.0.0"
-			}
-		},
 		"lcov-parse": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
@@ -1993,18 +1125,6 @@
 			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
 			"dev": true
 		},
-		"lodash.camelcase": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
-			"dev": true
-		},
-		"lodash.clone": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
-			"integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y=",
-			"dev": true
-		},
 		"lodash.sortby": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -2015,12 +1135,6 @@
 			"version": "1.2.7",
 			"resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
 			"integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
-			"dev": true
-		},
-		"long": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
-			"integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s=",
 			"dev": true
 		},
 		"magic-string": {
@@ -2159,22 +1273,6 @@
 			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 			"dev": true
 		},
-		"nan": {
-			"version": "2.14.1",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
-			"dev": true
-		},
-		"node-fetch": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-			"dev": true,
-			"requires": {
-				"encoding": "^0.1.11",
-				"is-stream": "^1.0.1"
-			}
-		},
 		"normalize-path": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
@@ -2183,12 +1281,6 @@
 			"requires": {
 				"remove-trailing-separator": "^1.0.1"
 			}
-		},
-		"number-is-nan": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-			"dev": true
 		},
 		"nwsapi": {
 			"version": "2.2.0",
@@ -3269,21 +2361,6 @@
 				"word-wrap": "~1.2.3"
 			}
 		},
-		"optjs": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/optjs/-/optjs-3.2.2.tgz",
-			"integrity": "sha1-aabOicRCpEQDFBrS+bNwvVu29O4=",
-			"dev": true
-		},
-		"os-locale": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-			"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-			"dev": true,
-			"requires": {
-				"lcid": "^1.0.0"
-			}
-		},
 		"parse-glob": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
@@ -3343,24 +2420,6 @@
 			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
 			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
 			"dev": true
-		},
-		"promise-polyfill": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.0.tgz",
-			"integrity": "sha512-OzSf6gcCUQ01byV4BgwyUCswlaQQ6gzXc23aLQWhicvfX9kfsUiUhgt3CCQej8jDnl8/PhGF31JdHX2/MzF3WA==",
-			"dev": true
-		},
-		"protobufjs": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-5.0.3.tgz",
-			"integrity": "sha512-55Kcx1MhPZX0zTbVosMQEO5R6/rikNXd9b6RQK4KSPcrSIIwoXTtebIczUrXlwaSrbz4x8XUVThGPob1n8I4QA==",
-			"dev": true,
-			"requires": {
-				"ascli": "~1",
-				"bytebuffer": "~5",
-				"glob": "^7.0.5",
-				"yargs": "^3.10.0"
-			}
 		},
 		"psl": {
 			"version": "1.8.0",
@@ -3676,26 +2735,6 @@
 			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
 			"dev": true
 		},
-		"string-width": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-			"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-			"dev": true,
-			"requires": {
-				"code-point-at": "^1.0.0",
-				"is-fullwidth-code-point": "^1.0.0",
-				"strip-ansi": "^3.0.0"
-			}
-		},
-		"strip-ansi": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-			"dev": true,
-			"requires": {
-				"ansi-regex": "^2.0.0"
-			}
-		},
 		"supports-color": {
 			"version": "5.4.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
@@ -3913,23 +2952,6 @@
 			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
 			"dev": true
 		},
-		"websocket-driver": {
-			"version": "0.7.4",
-			"resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-			"integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
-			"dev": true,
-			"requires": {
-				"http-parser-js": ">=0.5.1",
-				"safe-buffer": ">=5.1.0",
-				"websocket-extensions": ">=0.1.1"
-			}
-		},
-		"websocket-extensions": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
-			"integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
-			"dev": true
-		},
 		"whatwg-encoding": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
@@ -3950,12 +2972,6 @@
 				}
 			}
 		},
-		"whatwg-fetch": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.4.1.tgz",
-			"integrity": "sha512-sofZVzE1wKwO+EYPbWfiwzaKovWiZXf4coEzjGP9b2GBVgQRLQUZ2QcuPpQExGDAW5GItpEm6Tl4OU5mywnAoQ==",
-			"dev": true
-		},
 		"whatwg-mimetype": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
@@ -3973,27 +2989,11 @@
 				"webidl-conversions": "^4.0.2"
 			}
 		},
-		"window-size": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-			"integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
-			"dev": true
-		},
 		"word-wrap": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
 			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
 			"dev": true
-		},
-		"wrap-ansi": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-			"dev": true,
-			"requires": {
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1"
-			}
 		},
 		"wrappy": {
 			"version": "1.0.2",
@@ -4021,33 +3021,6 @@
 			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
 			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
 			"dev": true
-		},
-		"xmlhttprequest": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-			"integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=",
-			"dev": true
-		},
-		"y18n": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-			"dev": true
-		},
-		"yargs": {
-			"version": "3.32.0",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
-			"integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
-			"dev": true,
-			"requires": {
-				"camelcase": "^2.0.1",
-				"cliui": "^3.0.3",
-				"decamelize": "^1.1.1",
-				"os-locale": "^1.4.0",
-				"string-width": "^1.0.1",
-				"window-size": "^0.1.4",
-				"y18n": "^3.2.0"
-			}
 		},
 		"yn": {
 			"version": "3.1.1",

--- a/packages/geofire-common/package-lock.json
+++ b/packages/geofire-common/package-lock.json
@@ -140,6 +140,55 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
+		"@jridgewell/gen-mapping": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+			"integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+			"dev": true,
+			"requires": {
+				"@jridgewell/set-array": "^1.0.1",
+				"@jridgewell/sourcemap-codec": "^1.4.10",
+				"@jridgewell/trace-mapping": "^0.3.9"
+			}
+		},
+		"@jridgewell/resolve-uri": {
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.8.tgz",
+			"integrity": "sha512-YK5G9LaddzGbcucK4c8h5tWFmMPBvRZ/uyWmN1/SbBdIvqGUdWGkJ5BAaccgs6XbzVLsqbPJrBSFwKv3kT9i7w==",
+			"dev": true
+		},
+		"@jridgewell/set-array": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+			"dev": true
+		},
+		"@jridgewell/source-map": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+			"integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+			"dev": true,
+			"requires": {
+				"@jridgewell/gen-mapping": "^0.3.0",
+				"@jridgewell/trace-mapping": "^0.3.9"
+			}
+		},
+		"@jridgewell/sourcemap-codec": {
+			"version": "1.4.14",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+			"dev": true
+		},
+		"@jridgewell/trace-mapping": {
+			"version": "0.3.14",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
+			"integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+			"dev": true,
+			"requires": {
+				"@jridgewell/resolve-uri": "^3.0.3",
+				"@jridgewell/sourcemap-codec": "^1.4.10"
+			}
+		},
 		"@types/chai": {
 			"version": "4.2.12",
 			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.12.tgz",
@@ -964,27 +1013,6 @@
 				"@babel/types": "^7.4.0",
 				"istanbul-lib-coverage": "^2.0.5",
 				"semver": "^6.0.0"
-			}
-		},
-		"jest-worker": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.9.0.tgz",
-			"integrity": "sha512-51PE4haMSXcHohnSMdM42anbvZANYTqMrr52tVKPqqsPJMzoP6FYYDVqahX/HrAoKEKz3uUPzSvKs9A3qR4iVw==",
-			"dev": true,
-			"requires": {
-				"merge-stream": "^2.0.0",
-				"supports-color": "^6.1.0"
-			},
-			"dependencies": {
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"js-tokens": {
@@ -2464,6 +2492,15 @@
 				}
 			}
 		},
+		"randombytes": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "^5.1.0"
+			}
+		},
 		"regex-cache": {
 			"version": "0.4.4",
 			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
@@ -2591,6 +2628,55 @@
 				"resolve": "^1.10.0"
 			}
 		},
+		"rollup-plugin-terser": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
+			"integrity": "sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.10.4",
+				"jest-worker": "^26.2.1",
+				"serialize-javascript": "^4.0.0",
+				"terser": "^5.0.0"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"jest-worker": {
+					"version": "26.6.2",
+					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
+					"integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
+					"dev": true,
+					"requires": {
+						"@types/node": "*",
+						"merge-stream": "^2.0.0",
+						"supports-color": "^7.0.0"
+					}
+				},
+				"serialize-javascript": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+					"integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+					"dev": true,
+					"requires": {
+						"randombytes": "^2.1.0"
+					}
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
 		"rollup-plugin-typescript2": {
 			"version": "0.19.3",
 			"resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.19.3.tgz",
@@ -2630,18 +2716,6 @@
 				}
 			}
 		},
-		"rollup-plugin-uglify": {
-			"version": "6.0.4",
-			"resolved": "https://registry.npmjs.org/rollup-plugin-uglify/-/rollup-plugin-uglify-6.0.4.tgz",
-			"integrity": "sha512-ddgqkH02klveu34TF0JqygPwZnsbhHVI6t8+hGTcYHngPkQb5MIHI0XiztXIN/d6V9j+efwHAqEL7LspSxQXGw==",
-			"dev": true,
-			"requires": {
-				"@babel/code-frame": "^7.0.0",
-				"jest-worker": "^24.0.0",
-				"serialize-javascript": "^2.1.2",
-				"uglify-js": "^3.4.9"
-			}
-		},
 		"rollup-pluginutils": {
 			"version": "2.8.2",
 			"resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
@@ -2676,12 +2750,6 @@
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
 			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-			"dev": true
-		},
-		"serialize-javascript": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
-			"integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
 			"dev": true
 		},
 		"source-map": {
@@ -2749,6 +2817,42 @@
 			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
 			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
 			"dev": true
+		},
+		"terser": {
+			"version": "5.14.1",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.14.1.tgz",
+			"integrity": "sha512-+ahUAE+iheqBTDxXhTisdA8hgvbEG1hHOQ9xmNjeUJSoi6DU/gMrKNcfZjHkyY6Alnuyc+ikYJaxxfHkT3+WuQ==",
+			"dev": true,
+			"requires": {
+				"@jridgewell/source-map": "^0.3.2",
+				"acorn": "^8.5.0",
+				"commander": "^2.20.0",
+				"source-map-support": "~0.5.20"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "8.7.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+					"integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
+					"dev": true
+				},
+				"commander": {
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+					"dev": true
+				},
+				"source-map-support": {
+					"version": "0.5.21",
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+					"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+					"dev": true,
+					"requires": {
+						"buffer-from": "^1.0.0",
+						"source-map": "^0.6.0"
+					}
+				}
+			}
 		},
 		"to-fast-properties": {
 			"version": "2.0.0",
@@ -2886,12 +2990,6 @@
 			"version": "3.9.7",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
 			"integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
-			"dev": true
-		},
-		"uglify-js": {
-			"version": "3.10.4",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.4.tgz",
-			"integrity": "sha512-kBFT3U4Dcj4/pJ52vfjCSfyLyvG9VYYuGYPmrPvAxRw/i7xHiT4VvCev+uiEMcEEiu6UNB6KgWmGtSUYIWScbw==",
 			"dev": true
 		},
 		"universalify": {

--- a/packages/geofire-common/package-lock.json
+++ b/packages/geofire-common/package-lock.json
@@ -5,117 +5,115 @@
 	"requires": true,
 	"dependencies": {
 		"@babel/code-frame": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-			"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+			"integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
 			"dev": true,
 			"requires": {
-				"@babel/highlight": "^7.10.4"
+				"@babel/highlight": "^7.18.6"
 			}
 		},
 		"@babel/generator": {
-			"version": "7.11.6",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.6.tgz",
-			"integrity": "sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==",
+			"version": "7.18.7",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.7.tgz",
+			"integrity": "sha512-shck+7VLlY72a2w9c3zYWuE1pwOKEiQHV7GTUbSnhyl5eu3i04t30tBY82ZRWrDfo3gkakCFtevExnxbkf2a3A==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.11.5",
-				"jsesc": "^2.5.1",
-				"source-map": "^0.5.0"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-					"dev": true
-				}
+				"@babel/types": "^7.18.7",
+				"@jridgewell/gen-mapping": "^0.3.2",
+				"jsesc": "^2.5.1"
 			}
+		},
+		"@babel/helper-environment-visitor": {
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.6.tgz",
+			"integrity": "sha512-8n6gSfn2baOY+qlp+VSzsosjCVGFqWKmDF0cCWOybh52Dw3SEyoWR1KrhMJASjLwIEkkAufZ0xvr+SxLHSpy2Q==",
+			"dev": true
 		},
 		"@babel/helper-function-name": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-			"integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.18.6.tgz",
+			"integrity": "sha512-0mWMxV1aC97dhjCah5U5Ua7668r5ZmSC2DLfH2EZnf9c3/dHZKiFa5pRLMH5tjSl471tY6496ZWk/kjNONBxhw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-get-function-arity": "^7.10.4",
-				"@babel/template": "^7.10.4",
-				"@babel/types": "^7.10.4"
+				"@babel/template": "^7.18.6",
+				"@babel/types": "^7.18.6"
 			}
 		},
-		"@babel/helper-get-function-arity": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
-			"integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
+		"@babel/helper-hoist-variables": {
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
+			"integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.10.4"
+				"@babel/types": "^7.18.6"
 			}
 		},
 		"@babel/helper-split-export-declaration": {
-			"version": "7.11.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
-			"integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
+			"integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.11.0"
+				"@babel/types": "^7.18.6"
 			}
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-			"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
+			"integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
 			"dev": true
 		},
 		"@babel/highlight": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-			"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+			"integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.10.4",
+				"@babel/helper-validator-identifier": "^7.18.6",
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
 			}
 		},
 		"@babel/parser": {
-			"version": "7.11.5",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
-			"integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.6.tgz",
+			"integrity": "sha512-uQVSa9jJUe/G/304lXspfWVpKpK4euFLgGiMQFOCpM/bgcAdeoHwi/OQz23O9GK2osz26ZiXRRV9aV+Yl1O8tw==",
 			"dev": true
 		},
 		"@babel/template": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
-			"integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.6.tgz",
+			"integrity": "sha512-JoDWzPe+wgBsTTgdnIma3iHNFC7YVJoPssVBDjiHfNlyt4YcunDtcDOUmfVDfCK5MfdsaIoX9PkijPhjH3nYUw==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/parser": "^7.10.4",
-				"@babel/types": "^7.10.4"
+				"@babel/code-frame": "^7.18.6",
+				"@babel/parser": "^7.18.6",
+				"@babel/types": "^7.18.6"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.11.5",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.5.tgz",
-			"integrity": "sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.6.tgz",
+			"integrity": "sha512-zS/OKyqmD7lslOtFqbscH6gMLFYOfG1YPqCKfAW5KrTeolKqvB8UelR49Fpr6y93kYkW2Ik00mT1LOGiAGvizw==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/generator": "^7.11.5",
-				"@babel/helper-function-name": "^7.10.4",
-				"@babel/helper-split-export-declaration": "^7.11.0",
-				"@babel/parser": "^7.11.5",
-				"@babel/types": "^7.11.5",
+				"@babel/code-frame": "^7.18.6",
+				"@babel/generator": "^7.18.6",
+				"@babel/helper-environment-visitor": "^7.18.6",
+				"@babel/helper-function-name": "^7.18.6",
+				"@babel/helper-hoist-variables": "^7.18.6",
+				"@babel/helper-split-export-declaration": "^7.18.6",
+				"@babel/parser": "^7.18.6",
+				"@babel/types": "^7.18.6",
 				"debug": "^4.1.0",
-				"globals": "^11.1.0",
-				"lodash": "^4.17.19"
+				"globals": "^11.1.0"
 			},
 			"dependencies": {
 				"debug": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-					"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+					"version": "4.3.4",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+					"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
 					"dev": true,
 					"requires": {
 						"ms": "2.1.2"
@@ -130,13 +128,12 @@
 			}
 		},
 		"@babel/types": {
-			"version": "7.11.5",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-			"integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+			"version": "7.18.7",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.7.tgz",
+			"integrity": "sha512-QG3yxTcTIBoAcQmkCs+wAPYZhu7Dk9rXKacINfNbdJDNERTbLQbHGyVG8q/YGMPeCJRIhSY0+fTc5+xuh6WPSQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.10.4",
-				"lodash": "^4.17.19",
+				"@babel/helper-validator-identifier": "^7.18.6",
 				"to-fast-properties": "^2.0.0"
 			}
 		},
@@ -190,15 +187,15 @@
 			}
 		},
 		"@types/chai": {
-			"version": "4.2.12",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.12.tgz",
-			"integrity": "sha512-aN5IAC8QNtSUdQzxu7lGBgYAOuU1tmRU4c9dIq5OKGf/SBVjXo+ffM2wEjudAWbgpOhy60nLoAGH1xm8fpCKFQ==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.1.tgz",
+			"integrity": "sha512-/zPMqDkzSZ8t3VtxOa4KPq7uzzW978M9Tvh+j7GHKuo6k6GTLxPJ4J5gE5cjfJ26pnXst0N5Hax8Sr0T2Mi9zQ==",
 			"dev": true
 		},
 		"@types/estree": {
-			"version": "0.0.45",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.45.tgz",
-			"integrity": "sha512-jnqIUKDUqJbDIUxm0Uj7bnlMnRm1T/eZ9N+AVMqhPgzrba2GhGG5o/jCTwmdPK709nEZsGoMzXEDUjcXHa3W0g==",
+			"version": "0.0.52",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.52.tgz",
+			"integrity": "sha512-BZWrtCU0bMVAIliIV+HJO1f1PR41M7NKjfxrFJwwhKI1KwhwOxYw1SXg9ao+CIMt774nFuGiG6eU+udtbEI9oQ==",
 			"dev": true
 		},
 		"@types/mocha": {
@@ -208,9 +205,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "10.17.35",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.35.tgz",
-			"integrity": "sha512-gXx7jAWpMddu0f7a+L+txMplp3FnHl53OhQIF9puXKq3hDGY/GjH+MF04oWnV/adPSCrbtHumDCFwzq2VhltWA==",
+			"version": "10.17.60",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+			"integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
 			"dev": true
 		},
 		"@types/resolve": {
@@ -223,15 +220,15 @@
 			}
 		},
 		"abab": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
-			"integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
+			"integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
 			"dev": true
 		},
 		"acorn": {
-			"version": "6.4.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
-			"integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
+			"version": "6.4.2",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+			"integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
 			"dev": true
 		},
 		"acorn-globals": {
@@ -289,7 +286,7 @@
 		"arr-diff": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+			"integrity": "sha512-dtXTVMkh6VkEEA7OhXnN1Ecb8aAGFdZ1LFxtOCoqj4qkyOJMt7+qs6Ahdy6p/NQCPYsRSXXivhSB/J5E9jmYKA==",
 			"dev": true,
 			"requires": {
 				"arr-flatten": "^1.0.1"
@@ -304,19 +301,19 @@
 		"array-equal": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+			"integrity": "sha512-H3LU5RLiSsGXPhN+Nipar0iR0IofH+8r89G2y1tBKxQ/agagKyAjhkAFDRBfodP2caPrNKHpAWNIM/c9yeL7uA==",
 			"dev": true
 		},
 		"array-unique": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+			"integrity": "sha512-G2n5bG5fSUCpnsXz4+8FUkYsGPkNfLn9YvS66U5qbTIXI2Ynnlo4Bi42bWv+omKUCqz+ejzfClwne0alJWJPhg==",
 			"dev": true
 		},
 		"asn1": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+			"version": "0.2.6",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+			"integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
 			"dev": true,
 			"requires": {
 				"safer-buffer": "~2.1.0"
@@ -325,7 +322,7 @@
 		"assert-plus": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+			"integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
 			"dev": true
 		},
 		"assertion-error": {
@@ -343,31 +340,31 @@
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
 			"dev": true
 		},
 		"aws-sign2": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+			"integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
 			"dev": true
 		},
 		"aws4": {
-			"version": "1.10.1",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
-			"integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+			"integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
 			"dev": true
 		},
 		"balanced-match": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true
 		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+			"integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
 			"dev": true,
 			"requires": {
 				"tweetnacl": "^0.14.3"
@@ -386,7 +383,7 @@
 		"braces": {
 			"version": "1.8.5",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+			"integrity": "sha512-xU7bpz2ytJl1bH9cgIurjpg/n8Gohy9GTw81heDYLJQ4RU60dlyJsa+atVF2pI0yMMvKxI9HkKwjePCj5XI1hw==",
 			"dev": true,
 			"requires": {
 				"expand-range": "^1.8.1",
@@ -407,34 +404,35 @@
 			"dev": true
 		},
 		"buffer-from": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
 			"dev": true
 		},
 		"builtin-modules": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.1.0.tgz",
-			"integrity": "sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+			"integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
 			"dev": true
 		},
 		"caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+			"integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
 			"dev": true
 		},
 		"chai": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
-			"integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
+			"integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
 			"dev": true,
 			"requires": {
 				"assertion-error": "^1.1.0",
 				"check-error": "^1.0.2",
 				"deep-eql": "^3.0.1",
 				"get-func-name": "^2.0.0",
-				"pathval": "^1.1.0",
+				"loupe": "^2.3.1",
+				"pathval": "^1.1.1",
 				"type-detect": "^4.0.5"
 			}
 		},
@@ -452,7 +450,7 @@
 		"check-error": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+			"integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
 			"dev": true
 		},
 		"color-convert": {
@@ -467,7 +465,7 @@
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
 			"dev": true
 		},
 		"combined-stream": {
@@ -488,19 +486,19 @@
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
 			"dev": true
 		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
 			"dev": true
 		},
 		"coveralls": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.1.0.tgz",
-			"integrity": "sha512-sHxOu2ELzW8/NC1UP5XVLbZDzO4S3VxfFye3XYCznopHy02YjNkHcj5bKaVw2O7hVaBdBjEdQGpie4II1mWhuQ==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.1.1.tgz",
+			"integrity": "sha512-+dxnG2NHncSD1NrqbSM3dn/lE57O6Qf/koe9+I7c+wzkqRmEvcp0kgJdxKInzYzkICKkFMZsX3Vct3++tsF9ww==",
 			"dev": true,
 			"requires": {
 				"js-yaml": "^3.13.1",
@@ -528,7 +526,7 @@
 		"dashdash": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
 			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
@@ -564,15 +562,15 @@
 			}
 		},
 		"deep-is": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
 			"dev": true
 		},
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
 			"dev": true
 		},
 		"diff": {
@@ -593,7 +591,7 @@
 		"ecc-jsbn": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+			"integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
 			"dev": true,
 			"requires": {
 				"jsbn": "~0.1.0",
@@ -603,7 +601,7 @@
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
 			"dev": true
 		},
 		"escodegen": {
@@ -646,7 +644,7 @@
 		"expand-brackets": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+			"integrity": "sha512-hxx03P2dJxss6ceIeri9cmYOT4SRs3Zk3afZwWpOsRqLqprhTR8u++SlC+sFGsQr7WGFPdMF7Gjc1njDLDK6UA==",
 			"dev": true,
 			"requires": {
 				"is-posix-bracket": "^0.1.0"
@@ -655,7 +653,7 @@
 		"expand-range": {
 			"version": "1.8.2",
 			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+			"integrity": "sha512-AFASGfIlnIbkKPQwX1yHaDjFvh/1gyKJODme52V6IORh69uEYgZp0o9C+qsIGNVEiuuhQU0CSSl++Rlegg1qvA==",
 			"dev": true,
 			"requires": {
 				"fill-range": "^2.1.0"
@@ -670,7 +668,7 @@
 		"extglob": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+			"integrity": "sha512-1FOj1LOwn42TMrruOHGt18HemVnbwAmAak7krWk+wa93KXxGbK+2jpezm+ytJYDaBX0/SPLZFHKM7m+tKobWGg==",
 			"dev": true,
 			"requires": {
 				"is-extglob": "^1.0.0"
@@ -679,7 +677,7 @@
 		"extsprintf": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+			"integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
 			"dev": true
 		},
 		"fast-deep-equal": {
@@ -697,13 +695,13 @@
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
 			"dev": true
 		},
 		"filename-regex": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+			"integrity": "sha512-BTCqyBaWBTsauvnHiE8i562+EdJj+oUpkqWp2R1iCoR8f6oo8STRu3of7WJJ0TqWtxN50a5YFpzYK4Jj9esYfQ==",
 			"dev": true
 		},
 		"fill-range": {
@@ -722,13 +720,13 @@
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+			"integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==",
 			"dev": true
 		},
 		"for-own": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+			"integrity": "sha512-SKmowqGTJoPzLO1T0BBJpkfp3EMacCMOuH40hOUbrbzElVktk4DioXVM99QkLCyKoiuOmyjgcWMpVz2xjE7LZw==",
 			"dev": true,
 			"requires": {
 				"for-in": "^1.0.1"
@@ -737,7 +735,7 @@
 		"forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+			"integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
 			"dev": true
 		},
 		"form-data": {
@@ -765,28 +763,34 @@
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+			"dev": true
+		},
+		"function-bind": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
 			"dev": true
 		},
 		"get-func-name": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+			"integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
 			"dev": true
 		},
 		"getpass": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
 			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
 			}
 		},
 		"glob": {
-			"version": "7.1.6",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
@@ -800,7 +804,7 @@
 		"glob-base": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+			"integrity": "sha512-ab1S1g1EbO7YzauaJLkgLp7DZVAqj9M/dvKlTt8DkXA2tiOIcSMrlVI2J1RZyB5iJVccEscjGn+kpOG9788MHA==",
 			"dev": true,
 			"requires": {
 				"glob-parent": "^2.0.0",
@@ -810,7 +814,7 @@
 		"glob-parent": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+			"integrity": "sha512-JDYOvfxio/t42HKdxkAYaCiBN7oYiuxykOxKxdaUW5Qn0zaYN3gRQWolrwdnf0shM9/EP0ebuuTmyoXNr1cC5w==",
 			"dev": true,
 			"requires": {
 				"is-glob": "^2.0.0"
@@ -823,9 +827,9 @@
 			"dev": true
 		},
 		"graceful-fs": {
-			"version": "4.2.4",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-			"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+			"version": "4.2.10",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+			"integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
 			"dev": true
 		},
 		"growl": {
@@ -834,23 +838,10 @@
 			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
 			"dev": true
 		},
-		"handlebars": {
-			"version": "4.7.7",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
-			"integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
-			"dev": true,
-			"requires": {
-				"minimist": "^1.2.5",
-				"neo-async": "^2.6.0",
-				"source-map": "^0.6.1",
-				"uglify-js": "^3.1.4",
-				"wordwrap": "^1.0.0"
-			}
-		},
 		"har-schema": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+			"integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
 			"dev": true
 		},
 		"har-validator": {
@@ -863,22 +854,25 @@
 				"har-schema": "^2.0.0"
 			}
 		},
+		"has": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"dev": true,
+			"requires": {
+				"function-bind": "^1.1.1"
+			}
+		},
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
 			"dev": true
 		},
 		"he": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
-			"dev": true
-		},
-		"hosted-git-info": {
-			"version": "2.8.9",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-			"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+			"integrity": "sha512-z/GDPjlRMNOa2XJiB4em8wJpuuBfrFOlYKTZxtpkdr1uPdibHI8rYA3MY0KDObpVyaes0e/aunid/t88ZI2EKA==",
 			"dev": true
 		},
 		"html-encoding-sniffer": {
@@ -893,7 +887,7 @@
 		"http-signature": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+			"integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
 			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
@@ -901,10 +895,19 @@
 				"sshpk": "^1.7.0"
 			}
 		},
+		"iconv-lite": {
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"dev": true,
+			"requires": {
+				"safer-buffer": ">= 2.1.2 < 3"
+			}
+		},
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
 			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
@@ -923,16 +926,25 @@
 			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
 			"dev": true
 		},
+		"is-core-module": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+			"integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
+			"dev": true,
+			"requires": {
+				"has": "^1.0.3"
+			}
+		},
 		"is-dotfile": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+			"integrity": "sha512-9YclgOGtN/f8zx0Pr4FQYMdibBiTaH3sn52vjYip4ZSf6C4/6RfTEZ+MR4GvKhCxdPh21Bg42/WL55f6KSnKpg==",
 			"dev": true
 		},
 		"is-equal-shallow": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+			"integrity": "sha512-0EygVC5qPvIyb+gSz7zdD5/AAoS6Qrx1e//6N4yv4oNm30kqvdmG66oZFWVlQHUWe5OjP08FuTw2IdT0EOTcYA==",
 			"dev": true,
 			"requires": {
 				"is-primitive": "^2.0.0"
@@ -941,19 +953,19 @@
 		"is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
 			"dev": true
 		},
 		"is-extglob": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+			"integrity": "sha512-7Q+VbVafe6x2T+Tu6NcOf6sRklazEPmBoB3IWk3WdGZM2iGUwU/Oe3Wtq5lSEkDTTlpp8yx+5t4pzO/i9Ty1ww==",
 			"dev": true
 		},
 		"is-glob": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+			"integrity": "sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg==",
 			"dev": true,
 			"requires": {
 				"is-extglob": "^1.0.0"
@@ -962,13 +974,13 @@
 		"is-module": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
-			"integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
+			"integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
 			"dev": true
 		},
 		"is-number": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+			"integrity": "sha512-QUzH43Gfb9+5yckcrSA0VBDwEtDUchrk4F6tfJZQuNzDJbEDB9cZNzSfXGQ1jqmdDY/kl41lUOWM9syA8z8jlg==",
 			"dev": true,
 			"requires": {
 				"kind-of": "^3.0.2"
@@ -977,31 +989,31 @@
 		"is-posix-bracket": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+			"integrity": "sha512-Yu68oeXJ7LeWNmZ3Zov/xg/oDBnBK2RNxwYY1ilNJX+tKKZqgPK+qOn/Gs9jEu66KDY9Netf5XLKNGzas/vPfQ==",
 			"dev": true
 		},
 		"is-primitive": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+			"integrity": "sha512-N3w1tFaRfk3UrPfqeRyD+GYDASU3W5VinKhlORy8EWVf/sIdDL9GAcew85XmktCfH+ngG7SRXEVDoO18WMdB/Q==",
 			"dev": true
 		},
 		"is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+			"integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
 			"dev": true
 		},
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
 			"dev": true
 		},
 		"isobject": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+			"integrity": "sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==",
 			"dev": true,
 			"requires": {
 				"isarray": "1.0.0"
@@ -1010,7 +1022,7 @@
 		"isstream": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+			"integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
 			"dev": true
 		},
 		"istanbul-lib-coverage": {
@@ -1034,6 +1046,34 @@
 				"semver": "^6.0.0"
 			}
 		},
+		"jest-worker": {
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
+			"integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*",
+				"merge-stream": "^2.0.0",
+				"supports-color": "^7.0.0"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
 		"js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -1041,9 +1081,9 @@
 			"dev": true
 		},
 		"js-yaml": {
-			"version": "3.14.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
-			"integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+			"version": "3.14.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+			"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
 			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
@@ -1053,7 +1093,7 @@
 		"jsbn": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
 			"dev": true
 		},
 		"jsdom": {
@@ -1093,7 +1133,7 @@
 		"jsdom-global": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/jsdom-global/-/jsdom-global-3.0.2.tgz",
-			"integrity": "sha1-a9KZwTsMRiay2iwDk81DhdYGrLk=",
+			"integrity": "sha512-t1KMcBkz/pT5JrvcJbpUR2u/w1kO9jXctaaGJ0vZDzwFnIvGWw9IDSRciT83kIs8Bnw4qpOl8bQK08V01YgMPg==",
 			"dev": true
 		},
 		"jsesc": {
@@ -1103,9 +1143,9 @@
 			"dev": true
 		},
 		"json-schema": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+			"integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
 			"dev": true
 		},
 		"json-schema-traverse": {
@@ -1117,34 +1157,34 @@
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+			"integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
 			"dev": true
 		},
 		"jsonfile": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+			"integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.6"
 			}
 		},
 		"jsprim": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+			"integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
 			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"extsprintf": "1.3.0",
-				"json-schema": "0.2.3",
+				"json-schema": "0.4.0",
 				"verror": "1.10.0"
 			}
 		},
 		"kind-of": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
 			"dev": true,
 			"requires": {
 				"is-buffer": "^1.1.5"
@@ -1153,13 +1193,13 @@
 		"lcov-parse": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
-			"integrity": "sha1-6w1GtUER68VhrLTECO+TY73I9+A=",
+			"integrity": "sha512-aprLII/vPzuQvYZnDRU78Fns9I2Ag3gi4Ipga/hxnVMCZC8DnR2nI7XBqrPoywGfxqIx/DgarGvDJZAD3YBTgQ==",
 			"dev": true
 		},
 		"levn": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
 			"dev": true,
 			"requires": {
 				"prelude-ls": "~1.1.2",
@@ -1167,14 +1207,15 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.20",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+			"dev": true
 		},
 		"lodash.sortby": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+			"integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
 			"dev": true
 		},
 		"log-driver": {
@@ -1183,13 +1224,22 @@
 			"integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
 			"dev": true
 		},
-		"magic-string": {
-			"version": "0.25.7",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
-			"integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+		"loupe": {
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz",
+			"integrity": "sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==",
 			"dev": true,
 			"requires": {
-				"sourcemap-codec": "^1.4.4"
+				"get-func-name": "^2.0.0"
+			}
+		},
+		"magic-string": {
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+			"integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+			"dev": true,
+			"requires": {
+				"sourcemap-codec": "^1.4.8"
 			}
 		},
 		"make-error": {
@@ -1213,7 +1263,7 @@
 		"micromatch": {
 			"version": "2.3.11",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+			"integrity": "sha512-LnU2XFEk9xxSJ6rfgAry/ty5qwUTyHYOBU0g4R6tIw5ljwgGIBmiKhRWLw5NpMOnrgUNcDJ4WMp8rl3sYVHLNA==",
 			"dev": true,
 			"requires": {
 				"arr-diff": "^2.0.0",
@@ -1232,18 +1282,18 @@
 			}
 		},
 		"mime-db": {
-			"version": "1.44.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-			"integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
 			"dev": true
 		},
 		"mime-types": {
-			"version": "2.1.27",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
-			"integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
 			"dev": true,
 			"requires": {
-				"mime-db": "1.44.0"
+				"mime-db": "1.52.0"
 			}
 		},
 		"minimatch": {
@@ -1256,15 +1306,15 @@
 			}
 		},
 		"minimist": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
 			"dev": true
 		},
 		"mkdirp": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"integrity": "sha512-SknJC52obPfGQPnjIkXbmA6+5H15E+fR+E4iR2oQ3zzCLbd7/ONua69R/Gw7AgkTLsRG+r5fzksYwWe1AgTyWA==",
 			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
@@ -1273,7 +1323,7 @@
 				"minimist": {
 					"version": "0.0.8",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+					"integrity": "sha512-miQKw5Hv4NS1Psg2517mV4e4dYNaO3++hjAvLOAzKqZ61rH8NS1SK+vbfBWZ5PY/Me/bEWhUwqMghEW5Fb9T7Q==",
 					"dev": true
 				}
 			}
@@ -1295,49 +1345,27 @@
 				"minimatch": "3.0.4",
 				"mkdirp": "0.5.1",
 				"supports-color": "5.4.0"
-			},
-			"dependencies": {
-				"glob": {
-					"version": "7.1.2",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-					"dev": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				}
 			}
 		},
 		"ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-			"dev": true
-		},
-		"neo-async": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 			"dev": true
 		},
 		"normalize-path": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+			"integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
 			"dev": true,
 			"requires": {
 				"remove-trailing-separator": "^1.0.1"
 			}
 		},
 		"nwsapi": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
-			"integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.1.tgz",
+			"integrity": "sha512-JYOWTeFoS0Z93587vRJgASD5Ut11fYl5NyihP3KrYBvMe1FRRs6RN7m20SA/16GM4P6hTnZjT+UmDOt38UeXNg==",
 			"dev": true
 		},
 		"nyc": {
@@ -1398,6 +1426,7 @@
 				"async": {
 					"version": "2.6.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"lodash": "^4.17.11"
 					}
@@ -1449,7 +1478,9 @@
 				},
 				"commander": {
 					"version": "2.17.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true,
+					"optional": true
 				},
 				"commondir": {
 					"version": "1.0.1",
@@ -1611,6 +1642,24 @@
 					"bundled": true,
 					"dev": true
 				},
+				"handlebars": {
+					"version": "4.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"async": "^2.5.0",
+						"optimist": "^0.6.1",
+						"source-map": "^0.6.1",
+						"uglify-js": "^3.1.4"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.6.1",
+							"bundled": true,
+							"dev": true
+						}
+					}
+				},
 				"has-flag": {
 					"version": "3.0.0",
 					"bundled": true,
@@ -1623,6 +1672,11 @@
 					"requires": {
 						"is-stream": "^1.0.1"
 					}
+				},
+				"hosted-git-info": {
+					"version": "2.7.1",
+					"bundled": true,
+					"dev": true
 				},
 				"imurmurhash": {
 					"version": "0.1.4",
@@ -1761,6 +1815,11 @@
 						"path-exists": "^3.0.0"
 					}
 				},
+				"lodash": {
+					"version": "4.17.11",
+					"bundled": true,
+					"dev": true
+				},
 				"lodash.flattendeep": {
 					"version": "4.4.0",
 					"bundled": true,
@@ -1831,7 +1890,8 @@
 				},
 				"minimist": {
 					"version": "0.0.10",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"mkdirp": {
 					"version": "0.5.1",
@@ -1893,6 +1953,7 @@
 				"optimist": {
 					"version": "0.6.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"minimist": "~0.0.1",
 						"wordwrap": "~0.0.2"
@@ -1981,6 +2042,11 @@
 				},
 				"path-key": {
 					"version": "2.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"path-parse": {
+					"version": "1.0.6",
 					"bundled": true,
 					"dev": true
 				},
@@ -2192,6 +2258,8 @@
 				"uglify-js": {
 					"version": "3.4.9",
 					"bundled": true,
+					"dev": true,
+					"optional": true,
 					"requires": {
 						"commander": "~2.17.1",
 						"source-map": "~0.6.1"
@@ -2199,7 +2267,9 @@
 					"dependencies": {
 						"source-map": {
 							"version": "0.6.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true,
+							"optional": true
 						}
 					}
 				},
@@ -2232,7 +2302,8 @@
 				},
 				"wordwrap": {
 					"version": "0.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"wrap-ansi": {
 					"version": "2.1.0",
@@ -2291,6 +2362,11 @@
 						"signal-exit": "^3.0.2"
 					}
 				},
+				"y18n": {
+					"version": "4.0.0",
+					"bundled": true,
+					"dev": true
+				},
 				"yallist": {
 					"version": "2.1.2",
 					"bundled": true,
@@ -2335,7 +2411,7 @@
 		"object.omit": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+			"integrity": "sha512-UiAM5mhmIuKLsOvrL+B0U2d1hXHF3bFYWIuH1LMpuV2EJEHG1Ntz06PgLEHjm6VFd87NpH8rastvPoyv6UW2fA==",
 			"dev": true,
 			"requires": {
 				"for-own": "^0.1.4",
@@ -2345,7 +2421,7 @@
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
 			"dev": true,
 			"requires": {
 				"wrappy": "1"
@@ -2368,7 +2444,7 @@
 		"parse-glob": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+			"integrity": "sha512-FC5TeK0AwXzq3tUBFtH74naWkPQCEWs4K+xMxWZBlKDWu0bVHXGZa+KKqxKidd7xwhdZ19ZNuF2uO1M/r196HA==",
 			"dev": true,
 			"requires": {
 				"glob-base": "^0.3.0",
@@ -2386,7 +2462,7 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
 			"dev": true
 		},
 		"path-parse": {
@@ -2396,15 +2472,15 @@
 			"dev": true
 		},
 		"pathval": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+			"integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
 			"dev": true
 		},
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+			"integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
 			"dev": true
 		},
 		"pn": {
@@ -2416,13 +2492,13 @@
 		"prelude-ls": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+			"integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
 			"dev": true
 		},
 		"preserve": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+			"integrity": "sha512-s/46sYeylUfHNjI+sA/78FAHlmIuKqI9wNnzEOGehAlUUYeObv5C2mOinXBjyUyWmJ2SfcS2/ydApH4hTF4WXQ==",
 			"dev": true
 		},
 		"psl": {
@@ -2438,9 +2514,9 @@
 			"dev": true
 		},
 		"qs": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+			"integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
 			"dev": true
 		},
 		"randomatic": {
@@ -2489,19 +2565,19 @@
 		"remove-trailing-separator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+			"integrity": "sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==",
 			"dev": true
 		},
 		"repeat-element": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
-			"integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.4.tgz",
+			"integrity": "sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==",
 			"dev": true
 		},
 		"repeat-string": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+			"integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
 			"dev": true
 		},
 		"request": {
@@ -2553,12 +2629,14 @@
 			}
 		},
 		"resolve": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-			"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+			"version": "1.22.1",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+			"integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
 			"dev": true,
 			"requires": {
-				"path-parse": "^1.0.6"
+				"is-core-module": "^2.9.0",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
 			}
 		},
 		"rollup": {
@@ -2573,9 +2651,9 @@
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "7.4.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
-					"integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
+					"version": "7.4.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+					"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
 					"dev": true
 				}
 			}
@@ -2614,43 +2692,6 @@
 				"jest-worker": "^26.2.1",
 				"serialize-javascript": "^4.0.0",
 				"terser": "^5.0.0"
-			},
-			"dependencies": {
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"jest-worker": {
-					"version": "26.6.2",
-					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
-					"integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
-					"dev": true,
-					"requires": {
-						"@types/node": "*",
-						"merge-stream": "^2.0.0",
-						"supports-color": "^7.0.0"
-					}
-				},
-				"serialize-javascript": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
-					"integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
-					"dev": true,
-					"requires": {
-						"randombytes": "^2.1.0"
-					}
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
 			}
 		},
 		"rollup-plugin-typescript2": {
@@ -2728,6 +2769,15 @@
 			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 			"dev": true
 		},
+		"serialize-javascript": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+			"integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+			"dev": true,
+			"requires": {
+				"randombytes": "^2.1.0"
+			}
+		},
 		"source-map": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -2735,9 +2785,9 @@
 			"dev": true
 		},
 		"source-map-support": {
-			"version": "0.5.19",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-			"integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+			"version": "0.5.21",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
 			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
@@ -2753,13 +2803,13 @@
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
 			"dev": true
 		},
 		"sshpk": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
+			"integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
 			"dev": true,
 			"requires": {
 				"asn1": "~0.2.3",
@@ -2776,7 +2826,7 @@
 		"stealthy-require": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+			"integrity": "sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g==",
 			"dev": true
 		},
 		"supports-color": {
@@ -2787,6 +2837,12 @@
 			"requires": {
 				"has-flag": "^3.0.0"
 			}
+		},
+		"supports-preserve-symlinks-flag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+			"dev": true
 		},
 		"symbol-tree": {
 			"version": "3.2.4",
@@ -2817,23 +2873,13 @@
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
 					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
 					"dev": true
-				},
-				"source-map-support": {
-					"version": "0.5.21",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-					"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-					"dev": true,
-					"requires": {
-						"buffer-from": "^1.0.0",
-						"source-map": "^0.6.0"
-					}
 				}
 			}
 		},
 		"to-fast-properties": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+			"integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
 			"dev": true
 		},
 		"tough-cookie": {
@@ -2849,7 +2895,7 @@
 		"tr46": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+			"integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
 			"dev": true,
 			"requires": {
 				"punycode": "^2.1.0"
@@ -2906,7 +2952,7 @@
 				"builtin-modules": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-					"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+					"integrity": "sha512-wxXCdllwGhI2kCC0MnvTGYTMvnVZTvqgypkiTI8Pa5tcz2i6VqsqwYGgqwXji+4RgCzms6EajE4IxiUH6HH8nQ==",
 					"dev": true
 				},
 				"diff": {
@@ -2935,7 +2981,7 @@
 		"tunnel-agent": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
 			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.0.1"
@@ -2944,13 +2990,13 @@
 		"tweetnacl": {
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
 			"dev": true
 		},
 		"type-check": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
 			"dev": true,
 			"requires": {
 				"prelude-ls": "~1.1.2"
@@ -2963,17 +3009,10 @@
 			"dev": true
 		},
 		"typescript": {
-			"version": "3.9.7",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-			"integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+			"version": "3.9.10",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+			"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
 			"dev": true
-		},
-		"uglify-js": {
-			"version": "3.16.1",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.1.tgz",
-			"integrity": "sha512-X5BGTIDH8U6IQ1TIRP62YC36k+ULAa1d59BxlWvPUJ1NkW5L3FwcGfEzuVvGmhJFBu0YJ5Ge25tmRISqCmLiRQ==",
-			"dev": true,
-			"optional": true
 		},
 		"universalify": {
 			"version": "0.1.2",
@@ -2982,9 +3021,9 @@
 			"dev": true
 		},
 		"uri-js": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
-			"integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
 			"dev": true,
 			"requires": {
 				"punycode": "^2.1.0"
@@ -2999,7 +3038,7 @@
 		"verror": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
 			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
@@ -3040,17 +3079,6 @@
 			"dev": true,
 			"requires": {
 				"iconv-lite": "0.4.24"
-			},
-			"dependencies": {
-				"iconv-lite": {
-					"version": "0.4.24",
-					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-					"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-					"dev": true,
-					"requires": {
-						"safer-buffer": ">= 2.1.2 < 3"
-					}
-				}
 			}
 		},
 		"whatwg-mimetype": {
@@ -3076,16 +3104,10 @@
 			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
 			"dev": true
 		},
-		"wordwrap": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-			"integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
-			"dev": true
-		},
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
 			"dev": true
 		},
 		"ws": {
@@ -3107,12 +3129,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
 			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-			"dev": true
-		},
-		"y18n": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-			"integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
 			"dev": true
 		},
 		"yn": {

--- a/packages/geofire-common/package-lock.json
+++ b/packages/geofire-common/package-lock.json
@@ -834,6 +834,19 @@
 			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
 			"dev": true
 		},
+		"handlebars": {
+			"version": "4.7.7",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+			"integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+			"dev": true,
+			"requires": {
+				"minimist": "^1.2.5",
+				"neo-async": "^2.6.0",
+				"source-map": "^0.6.1",
+				"uglify-js": "^3.1.4",
+				"wordwrap": "^1.0.0"
+			}
+		},
 		"har-schema": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -1156,8 +1169,7 @@
 		"lodash": {
 			"version": "4.17.20",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-			"dev": true
+			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
 		},
 		"lodash.sortby": {
 			"version": "4.7.0",
@@ -1307,6 +1319,12 @@
 			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 			"dev": true
 		},
+		"neo-async": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+			"dev": true
+		},
 		"normalize-path": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
@@ -1431,8 +1449,7 @@
 				},
 				"commander": {
 					"version": "2.17.1",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"commondir": {
 					"version": "1.0.1",
@@ -2182,8 +2199,7 @@
 					"dependencies": {
 						"source-map": {
 							"version": "0.6.1",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						}
 					}
 				},
@@ -2952,6 +2968,13 @@
 			"integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
 			"dev": true
 		},
+		"uglify-js": {
+			"version": "3.16.1",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.1.tgz",
+			"integrity": "sha512-X5BGTIDH8U6IQ1TIRP62YC36k+ULAa1d59BxlWvPUJ1NkW5L3FwcGfEzuVvGmhJFBu0YJ5Ge25tmRISqCmLiRQ==",
+			"dev": true,
+			"optional": true
+		},
 		"universalify": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -3053,6 +3076,12 @@
 			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
 			"dev": true
 		},
+		"wordwrap": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+			"integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+			"dev": true
+		},
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -3078,6 +3107,12 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
 			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+			"dev": true
+		},
+		"y18n": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+			"integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
 			"dev": true
 		},
 		"yn": {

--- a/packages/geofire-common/package.json
+++ b/packages/geofire-common/package.json
@@ -50,7 +50,7 @@
     "rollup-plugin-commonjs": "^9.2.0",
     "rollup-plugin-node-resolve": "^4.0.0",
     "rollup-plugin-typescript2": "^0.19.2",
-    "rollup-plugin-uglify": "^6.0.2",
+    "rollup-plugin-terser": "^7.0.2",
     "source-map-support": "^0.5.10",
     "ts-node": "^8.0.2",
     "tslint": "^5.12.1",

--- a/packages/geofire-common/rollup.config.js
+++ b/packages/geofire-common/rollup.config.js
@@ -1,7 +1,7 @@
 import commonjs from 'rollup-plugin-commonjs';
 import resolveModule from 'rollup-plugin-node-resolve';
 import typescript from 'rollup-plugin-typescript2';
-import { uglify } from 'rollup-plugin-uglify';
+import { terser } from 'rollup-plugin-terser';
 import pkg from './package.json';
 
 const GLOBAL_NAME = 'geofire-common';
@@ -34,7 +34,7 @@ const completeBuilds = [{
       format: 'umd',
       name: GLOBAL_NAME
     },
-    plugins: [...plugins, uglify()]
+    plugins: [...plugins, terser()]
   },
   {
     input: 'src/index.ts',

--- a/packages/geofire/package-lock.json
+++ b/packages/geofire/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "geofire",
-	"version": "5.1.0",
+	"version": "5.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -124,17 +124,45 @@
 			}
 		},
 		"@firebase/analytics": {
-			"version": "0.6.3",
-			"resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.6.3.tgz",
-			"integrity": "sha512-W+H1PbhDtxKJMPfb2/Iy0wZiTpf5xZ33rKTakeVd8j2p1emm2lwrlrv0+/qg7BUqeuxgma5AB3U0bwS0iSSaww==",
+			"version": "0.0.900-exp.b0c8425bc",
+			"resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.0.900-exp.b0c8425bc.tgz",
+			"integrity": "sha512-QfgzaqsyftbZ21cPpCpHD/zQ45OCxT8tY0QK50nCUxXkJdKO9nk9Jot5LA3VFUcS6Qvo+fdcbC31Yg/y8xowXA==",
 			"dev": true,
 			"requires": {
-				"@firebase/analytics-types": "0.4.0",
-				"@firebase/component": "0.1.21",
-				"@firebase/installations": "0.4.19",
+				"@firebase/component": "0.4.0",
+				"@firebase/installations": "0.0.900-exp.b0c8425bc",
 				"@firebase/logger": "0.2.6",
-				"@firebase/util": "0.3.4",
-				"tslib": "^1.11.1"
+				"@firebase/util": "0.4.1",
+				"tslib": "^2.1.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"dev": true
+				}
+			}
+		},
+		"@firebase/analytics-compat": {
+			"version": "0.0.900-exp.b0c8425bc",
+			"resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.0.900-exp.b0c8425bc.tgz",
+			"integrity": "sha512-UeOBK/f6RRezJCYGp7XFDowP8ezNCbJyg0Otyd3HByV1ZcIJn0Wnl80/iQ1Ybk9iN5hCIM9uyoYNnTe9ViKmag==",
+			"dev": true,
+			"requires": {
+				"@firebase/analytics": "0.0.900-exp.b0c8425bc",
+				"@firebase/analytics-types": "0.4.0",
+				"@firebase/component": "0.4.0",
+				"@firebase/util": "0.4.1",
+				"tslib": "^2.1.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"dev": true
+				}
 			}
 		},
 		"@firebase/analytics-types": {
@@ -144,18 +172,46 @@
 			"dev": true
 		},
 		"@firebase/app": {
-			"version": "0.6.14",
-			"resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.6.14.tgz",
-			"integrity": "sha512-ZQKuiJ+fzr4tULgWoXbW+AZVTGsejOkSrlQ+zx78WiGKIubpFJLklnP3S0oYr/1nHzr4vaKuM4G8IL1Wv/+MpQ==",
+			"version": "0.0.900-exp.b0c8425bc",
+			"resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.0.900-exp.b0c8425bc.tgz",
+			"integrity": "sha512-WvWPl2ZwzTHkwawuP9SL81S9ciDSlaEkdrfnc12ZrmQJVVZDHMUDkrmV4DMXcBKtYLO2JlJzmlCNKOEZwzHBdw==",
 			"dev": true,
 			"requires": {
-				"@firebase/app-types": "0.6.1",
-				"@firebase/component": "0.1.21",
+				"@firebase/component": "0.4.0",
 				"@firebase/logger": "0.2.6",
-				"@firebase/util": "0.3.4",
+				"@firebase/util": "0.4.1",
+				"tslib": "^2.1.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"dev": true
+				}
+			}
+		},
+		"@firebase/app-compat": {
+			"version": "0.0.900-exp.b0c8425bc",
+			"resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.0.900-exp.b0c8425bc.tgz",
+			"integrity": "sha512-bSivtLuYVpP5mfftx7wTrBUgCbJD+K6BqYMF+gCj2C3c4KdAWnUJDdJhK9BELnbVzIY/N+L95RZn9XodmXKF+A==",
+			"dev": true,
+			"requires": {
+				"@firebase/app": "0.0.900-exp.b0c8425bc",
+				"@firebase/component": "0.4.0",
+				"@firebase/logger": "0.2.6",
+				"@firebase/util": "0.4.1",
 				"dom-storage": "2.1.0",
-				"tslib": "^1.11.1",
+				"tslib": "^2.1.0",
 				"xmlhttprequest": "1.8.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"dev": true
+				}
 			}
 		},
 		"@firebase/app-types": {
@@ -164,12 +220,47 @@
 			"integrity": "sha512-L/ZnJRAq7F++utfuoTKX4CLBG5YR7tFO3PLzG1/oXXKEezJ0kRL3CMRoueBEmTCzVb/6SIs2Qlaw++uDgi5Xyg=="
 		},
 		"@firebase/auth": {
-			"version": "0.16.4",
-			"resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.16.4.tgz",
-			"integrity": "sha512-zgHPK6/uL6+nAyG9zqammHTF1MQpAN7z/jVRLYkDZS4l81H08b2SzApLbRfW/fmy665xqb5MK7sVH0V1wsiCNw==",
+			"version": "0.0.900-exp.b0c8425bc",
+			"resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.0.900-exp.b0c8425bc.tgz",
+			"integrity": "sha512-KNG8CQJ6t5EyBOMd5967DgaM0LYObN9Af39I3AF4KXLfAKJNQnqxPP5dGn01mWk3Em/xUF2uRKsnjWbKY5EnSQ==",
 			"dev": true,
 			"requires": {
-				"@firebase/auth-types": "0.10.2"
+				"@firebase/component": "0.4.0",
+				"@firebase/logger": "0.2.6",
+				"@firebase/util": "0.4.1",
+				"node-fetch": "2.6.1",
+				"selenium-webdriver": "4.0.0-beta.1",
+				"tslib": "^2.1.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"dev": true
+				}
+			}
+		},
+		"@firebase/auth-compat": {
+			"version": "0.0.900-exp.b0c8425bc",
+			"resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.0.900-exp.b0c8425bc.tgz",
+			"integrity": "sha512-Ve6+sYwdQgCNljsCQ/IsDrYkvESG3+W5q1u+90RFPK6TzLnloRyY4ECD8RIAMleJBzFnwfhfACRBjR9qZixbFQ==",
+			"dev": true,
+			"requires": {
+				"@firebase/auth": "0.0.900-exp.b0c8425bc",
+				"@firebase/auth-types": "0.10.2",
+				"@firebase/component": "0.4.0",
+				"@firebase/util": "0.4.1",
+				"node-fetch": "2.6.1",
+				"tslib": "^2.1.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"dev": true
+				}
 			}
 		},
 		"@firebase/auth-interop-types": {
@@ -185,28 +276,98 @@
 			"dev": true
 		},
 		"@firebase/component": {
-			"version": "0.1.21",
-			"resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.21.tgz",
-			"integrity": "sha512-kd5sVmCLB95EK81Pj+yDTea8pzN2qo/1yr0ua9yVi6UgMzm6zAeih73iVUkaat96MAHy26yosMufkvd3zC4IKg==",
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.4.0.tgz",
+			"integrity": "sha512-L7kLKpW1v5qxPfIhx/VqHuVi+vr5IcnDS4zCJFb+/eYe23i6czSOWR1urAoJ4r42Dk0XB5kDt6Idojdd9BGMEA==",
 			"dev": true,
 			"requires": {
-				"@firebase/util": "0.3.4",
-				"tslib": "^1.11.1"
+				"@firebase/util": "0.4.1",
+				"tslib": "^2.1.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"dev": true
+				}
 			}
 		},
 		"@firebase/database": {
-			"version": "0.9.3",
-			"resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.9.3.tgz",
-			"integrity": "sha512-/ZxABwwknVFypPivQGRauF0WE9ZNr+WCucwCqAhxzQPgfUOaAKL5PZs9Oa/Yz42gMMfmjF+z6hPvSjW2ePlEcA==",
+			"version": "0.0.900-exp.b0c8425bc",
+			"resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.0.900-exp.b0c8425bc.tgz",
+			"integrity": "sha512-GnEEqWZN4gc/plLEkkBOFkT984L/EfH8GIPfsaEqib1+1RJ7Pbh2vxXN3SHEoaODIh/VOCeQ36HM9Ip5/aTvHg==",
 			"dev": true,
 			"requires": {
 				"@firebase/auth-interop-types": "0.1.5",
-				"@firebase/component": "0.1.21",
-				"@firebase/database-types": "0.7.0",
+				"@firebase/component": "0.4.0",
+				"@firebase/database-types": "0.7.1",
 				"@firebase/logger": "0.2.6",
-				"@firebase/util": "0.3.4",
+				"@firebase/util": "0.4.1",
 				"faye-websocket": "0.11.3",
-				"tslib": "^1.11.1"
+				"tslib": "^2.1.0"
+			},
+			"dependencies": {
+				"@firebase/app-types": {
+					"version": "0.6.2",
+					"resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.6.2.tgz",
+					"integrity": "sha512-2VXvq/K+n8XMdM4L2xy5bYp2ZXMawJXluUIDzUBvMthVR+lhxK4pfFiqr1mmDbv9ydXvEAuFsD+6DpcZuJcSSw==",
+					"dev": true
+				},
+				"@firebase/database-types": {
+					"version": "0.7.1",
+					"resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.7.1.tgz",
+					"integrity": "sha512-465ceJXSMqFFMnL2lxYx+YhYajcyk+VpGiXf9T6KNME0lKne5hYuqYr7XmS8/sTeyV0huhmTb8K1nxlA7hiPOg==",
+					"dev": true,
+					"requires": {
+						"@firebase/app-types": "0.6.2"
+					}
+				},
+				"tslib": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"dev": true
+				}
+			}
+		},
+		"@firebase/database-compat": {
+			"version": "0.0.900-exp.b0c8425bc",
+			"resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-0.0.900-exp.b0c8425bc.tgz",
+			"integrity": "sha512-s1lTGei5CN163b3qsAYOqclHzj7gbQbWxYJZE1YWO3TDOjYyHpElH93yfKl9LuAB2ptNf+WxZ2Z8Cppff9cAFQ==",
+			"dev": true,
+			"requires": {
+				"@firebase/auth-interop-types": "0.1.5",
+				"@firebase/component": "0.4.0",
+				"@firebase/database": "0.0.900-exp.b0c8425bc",
+				"@firebase/database-types": "0.7.1",
+				"@firebase/logger": "0.2.6",
+				"@firebase/util": "0.4.1",
+				"faye-websocket": "0.11.3",
+				"tslib": "^2.1.0"
+			},
+			"dependencies": {
+				"@firebase/app-types": {
+					"version": "0.6.2",
+					"resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.6.2.tgz",
+					"integrity": "sha512-2VXvq/K+n8XMdM4L2xy5bYp2ZXMawJXluUIDzUBvMthVR+lhxK4pfFiqr1mmDbv9ydXvEAuFsD+6DpcZuJcSSw==",
+					"dev": true
+				},
+				"@firebase/database-types": {
+					"version": "0.7.1",
+					"resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.7.1.tgz",
+					"integrity": "sha512-465ceJXSMqFFMnL2lxYx+YhYajcyk+VpGiXf9T6KNME0lKne5hYuqYr7XmS8/sTeyV0huhmTb8K1nxlA7hiPOg==",
+					"dev": true,
+					"requires": {
+						"@firebase/app-types": "0.6.2"
+					}
+				},
+				"tslib": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"dev": true
+				}
 			}
 		},
 		"@firebase/database-types": {
@@ -218,39 +379,103 @@
 			}
 		},
 		"@firebase/firestore": {
-			"version": "2.1.6",
-			"resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-2.1.6.tgz",
-			"integrity": "sha512-T7hNYP6lH3i6rqAzXvIqh30GmUvAl+6C4yUvrdHtz+RO3MeReK1TCE4mmAWBZApLCibVIZiMJ581qRB8KnON7A==",
+			"version": "0.0.900-exp.b0c8425bc",
+			"resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-0.0.900-exp.b0c8425bc.tgz",
+			"integrity": "sha512-XZZYA/oe2nTMf1GWoPcH5BPYbz6BgBpXm89In4zkx6jKVh944/wuQRCZEuR93AOJLeRDJw/4ZskqES8G0GTqXA==",
 			"dev": true,
 			"requires": {
-				"@firebase/component": "0.1.21",
-				"@firebase/firestore-types": "2.1.0",
+				"@firebase/component": "0.4.0",
+				"@firebase/firestore-types": "2.2.0",
 				"@firebase/logger": "0.2.6",
-				"@firebase/util": "0.3.4",
+				"@firebase/util": "0.4.1",
 				"@firebase/webchannel-wrapper": "0.4.1",
 				"@grpc/grpc-js": "^1.0.0",
 				"@grpc/proto-loader": "^0.5.0",
 				"node-fetch": "2.6.1",
-				"tslib": "^1.11.1"
+				"tslib": "^2.1.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"dev": true
+				}
+			}
+		},
+		"@firebase/firestore-compat": {
+			"version": "0.0.900-exp.b0c8425bc",
+			"resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.0.900-exp.b0c8425bc.tgz",
+			"integrity": "sha512-H0IUTWK4A3s2V6eBpnxF9w+0kuBQU18lzfkxHKayoAXHNoXb3vjiC0RHVjY8eY0ahHW90+nDqFIXaJ/Z7EteQw==",
+			"dev": true,
+			"requires": {
+				"@firebase/component": "0.4.0",
+				"@firebase/firestore": "0.0.900-exp.b0c8425bc",
+				"@firebase/firestore-types": "2.2.0",
+				"@firebase/logger": "0.2.6",
+				"@firebase/util": "0.4.1",
+				"@firebase/webchannel-wrapper": "0.4.1",
+				"@grpc/grpc-js": "^1.0.0",
+				"@grpc/proto-loader": "^0.5.0",
+				"node-fetch": "2.6.1",
+				"tslib": "^2.1.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"dev": true
+				}
 			}
 		},
 		"@firebase/firestore-types": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-2.1.0.tgz",
-			"integrity": "sha512-jietErBWihMvJkqqEquQy5GgoEwzHnMXXC/TsVoe9FPysXm1/AeJS12taS7ZYvenAtyvL/AEJyKrRKRh4adcJQ==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-2.2.0.tgz",
+			"integrity": "sha512-5kZZtQ32FIRJP1029dw+ZVNRCclKOErHv1+Xn0pw/5Fq3dxroA/ZyFHqDu+uV52AyWHhNLjCqX43ibm4YqOzRw==",
 			"dev": true
 		},
 		"@firebase/functions": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.6.1.tgz",
-			"integrity": "sha512-xNCAY3cLlVWE8Azf+/84OjnaXMoyUstJ3vwVRG0ie22QhsdQuPa1tXTiPX4Tmm+Hbbd/Aw0A/7dkEnuW+zYzaQ==",
+			"version": "0.0.900-exp.b0c8425bc",
+			"resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.0.900-exp.b0c8425bc.tgz",
+			"integrity": "sha512-7YZMEMr+xCgSUWWBbampEjl+w+ZR2yuhAIFD/p8TqGfKOQWNQciwNvqOX/+qG+SqjDmPb+p+/3LFvxQT68YSyA==",
 			"dev": true,
 			"requires": {
-				"@firebase/component": "0.1.21",
+				"@firebase/component": "0.4.0",
+				"@firebase/messaging-types": "0.5.0",
+				"@firebase/util": "0.4.1",
+				"node-fetch": "2.6.1",
+				"tslib": "^2.1.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"dev": true
+				}
+			}
+		},
+		"@firebase/functions-compat": {
+			"version": "0.0.900-exp.b0c8425bc",
+			"resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.0.900-exp.b0c8425bc.tgz",
+			"integrity": "sha512-6lCfY6cX6aFgbkVrnSd/zF9gYRo44eDQz/DGtOttkShdWkoOQrct4yAN044VAxZJ2A1vcM1mq2WCLlYLq3AEAw==",
+			"dev": true,
+			"requires": {
+				"@firebase/component": "0.4.0",
+				"@firebase/functions": "0.0.900-exp.b0c8425bc",
 				"@firebase/functions-types": "0.4.0",
 				"@firebase/messaging-types": "0.5.0",
-				"node-fetch": "2.6.1",
-				"tslib": "^1.11.1"
+				"@firebase/util": "0.4.1",
+				"tslib": "^2.1.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"dev": true
+				}
 			}
 		},
 		"@firebase/functions-types": {
@@ -260,23 +485,24 @@
 			"dev": true
 		},
 		"@firebase/installations": {
-			"version": "0.4.19",
-			"resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.4.19.tgz",
-			"integrity": "sha512-QqAQzosKVVqIx7oMt5ujF4NsIXgtlTnej4JXGJ8sQQuJoMnt3T+PFQRHbr7uOfVaBiHYhEaXCcmmhfKUHwKftw==",
+			"version": "0.0.900-exp.b0c8425bc",
+			"resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.0.900-exp.b0c8425bc.tgz",
+			"integrity": "sha512-XsYWVbKQdP4WmMYAIMTk6A3inv1jHBxDXgtReQ58WH1GrVwyNSoACpJK/TzIAeOugRSARkcF5f2E0yoVujBZog==",
 			"dev": true,
 			"requires": {
-				"@firebase/component": "0.1.21",
-				"@firebase/installations-types": "0.3.4",
-				"@firebase/util": "0.3.4",
+				"@firebase/component": "0.4.0",
+				"@firebase/util": "0.4.1",
 				"idb": "3.0.2",
-				"tslib": "^1.11.1"
+				"tslib": "^2.1.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"dev": true
+				}
 			}
-		},
-		"@firebase/installations-types": {
-			"version": "0.3.4",
-			"resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.3.4.tgz",
-			"integrity": "sha512-RfePJFovmdIXb6rYwtngyxuEcWnOrzdZd9m7xAW0gRxDIjBT20n3BOhjpmgRWXo/DAxRmS7bRjWAyTHY9cqN7Q==",
-			"dev": true
 		},
 		"@firebase/logger": {
 			"version": "0.2.6",
@@ -285,17 +511,45 @@
 			"dev": true
 		},
 		"@firebase/messaging": {
-			"version": "0.7.3",
-			"resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.7.3.tgz",
-			"integrity": "sha512-63nOP2SmQJrj9jrhV3K96L5MRKS6AqmFVLX1XbGk6K6lz38ZC4LIoCcHxzUBXY7fCAuZvNmh/YB3pE8B2mTs8A==",
+			"version": "0.0.900-exp.b0c8425bc",
+			"resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.0.900-exp.b0c8425bc.tgz",
+			"integrity": "sha512-HOrZHjPGqLgQAl/5BDICN6KjExL+Ap7NTAyN9DvQxCO6WLt+hacgJR7XXuqsr2a/teB6INh5qnmOPC/DCy7fog==",
 			"dev": true,
 			"requires": {
-				"@firebase/component": "0.1.21",
-				"@firebase/installations": "0.4.19",
-				"@firebase/messaging-types": "0.5.0",
-				"@firebase/util": "0.3.4",
+				"@firebase/component": "0.4.0",
+				"@firebase/installations": "0.0.900-exp.b0c8425bc",
+				"@firebase/util": "0.4.1",
 				"idb": "3.0.2",
-				"tslib": "^1.11.1"
+				"tslib": "^2.1.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"dev": true
+				}
+			}
+		},
+		"@firebase/messaging-compat": {
+			"version": "0.0.900-exp.b0c8425bc",
+			"resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.0.900-exp.b0c8425bc.tgz",
+			"integrity": "sha512-beNO8moaXJaLGsn1xL14urNN87p1PRTr924bSHNJ77dCF7EYHJZz8q+goegbO/fFa6SDplKzSexSOgSEGMagGQ==",
+			"dev": true,
+			"requires": {
+				"@firebase/component": "0.4.0",
+				"@firebase/installations": "0.0.900-exp.b0c8425bc",
+				"@firebase/messaging": "0.0.900-exp.b0c8425bc",
+				"@firebase/util": "0.4.1",
+				"tslib": "^2.1.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"dev": true
+				}
 			}
 		},
 		"@firebase/messaging-types": {
@@ -305,17 +559,46 @@
 			"dev": true
 		},
 		"@firebase/performance": {
-			"version": "0.4.5",
-			"resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.4.5.tgz",
-			"integrity": "sha512-oenEOaV/UzvV8XPi8afYQ71RzyrHoBesqOyXqb1TOg7dpU+i+UJ5PS8K64DytKUHTxQl+UJFcuxNpsoy9BpWzw==",
+			"version": "0.0.900-exp.b0c8425bc",
+			"resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.0.900-exp.b0c8425bc.tgz",
+			"integrity": "sha512-DLrf8k1F7kUJ6WrrojwiHAxLw9D8SD7znxaJ7UejYUqhnJGs8CeHHuHfKHUfnm5462CLBUYRUpXOFVVV9TaCHQ==",
 			"dev": true,
 			"requires": {
-				"@firebase/component": "0.1.21",
-				"@firebase/installations": "0.4.19",
+				"@firebase/component": "0.4.0",
+				"@firebase/installations": "0.0.900-exp.b0c8425bc",
 				"@firebase/logger": "0.2.6",
+				"@firebase/util": "0.4.1",
+				"tslib": "^2.1.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"dev": true
+				}
+			}
+		},
+		"@firebase/performance-compat": {
+			"version": "0.0.900-exp.b0c8425bc",
+			"resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.0.900-exp.b0c8425bc.tgz",
+			"integrity": "sha512-Z9fTL+2dQGjeAgPFuHz0DRwnm1SZdAhhJb35pDX48TmOchtVpviLXVEzgLb/1zfAlyyB6QwTcboInmvMNqgh2A==",
+			"dev": true,
+			"requires": {
+				"@firebase/component": "0.4.0",
+				"@firebase/logger": "0.2.6",
+				"@firebase/performance": "0.0.900-exp.b0c8425bc",
 				"@firebase/performance-types": "0.0.13",
-				"@firebase/util": "0.3.4",
-				"tslib": "^1.11.1"
+				"@firebase/util": "0.4.1",
+				"tslib": "^2.1.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"dev": true
+				}
 			}
 		},
 		"@firebase/performance-types": {
@@ -324,29 +607,47 @@
 			"integrity": "sha512-6fZfIGjQpwo9S5OzMpPyqgYAUZcFzZxHFqOyNtorDIgNXq33nlldTL/vtaUZA8iT9TT5cJlCrF/jthKU7X21EA==",
 			"dev": true
 		},
-		"@firebase/polyfill": {
-			"version": "0.3.36",
-			"resolved": "https://registry.npmjs.org/@firebase/polyfill/-/polyfill-0.3.36.tgz",
-			"integrity": "sha512-zMM9oSJgY6cT2jx3Ce9LYqb0eIpDE52meIzd/oe/y70F+v9u1LDqk5kUF5mf16zovGBWMNFmgzlsh6Wj0OsFtg==",
+		"@firebase/remote-config": {
+			"version": "0.0.900-exp.b0c8425bc",
+			"resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.0.900-exp.b0c8425bc.tgz",
+			"integrity": "sha512-CjpNgnN+OyX23KrKs/H/OS8AzGnIopzv3khSLfRydC9qjs1UARt/bAd1TGN7b/pwvA+OGHeal3AHJhgbmxp9kg==",
 			"dev": true,
 			"requires": {
-				"core-js": "3.6.5",
-				"promise-polyfill": "8.1.3",
-				"whatwg-fetch": "2.0.4"
+				"@firebase/component": "0.4.0",
+				"@firebase/installations": "0.0.900-exp.b0c8425bc",
+				"@firebase/logger": "0.2.6",
+				"@firebase/util": "0.4.1",
+				"tslib": "^2.1.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"dev": true
+				}
 			}
 		},
-		"@firebase/remote-config": {
-			"version": "0.1.30",
-			"resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.30.tgz",
-			"integrity": "sha512-LAfLDcp1AN0V/7AkxBuTKy+Qnq9fKYKxbA5clrXRNVzJbTVnF5eFGsaUOlkes0ESG6lbqKy5ZcDgdl73zBIhAA==",
+		"@firebase/remote-config-compat": {
+			"version": "0.0.900-exp.b0c8425bc",
+			"resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.0.900-exp.b0c8425bc.tgz",
+			"integrity": "sha512-QcuaxoXicecffLiXzyS09P0f1ufZ7JU/WhiTGgXCOQ+EQMuAefqYQNNixxtWVSKC/LCEd+BhEH76vMh2TAKwFw==",
 			"dev": true,
 			"requires": {
-				"@firebase/component": "0.1.21",
-				"@firebase/installations": "0.4.19",
+				"@firebase/component": "0.4.0",
 				"@firebase/logger": "0.2.6",
+				"@firebase/remote-config": "0.0.900-exp.b0c8425bc",
 				"@firebase/remote-config-types": "0.1.9",
-				"@firebase/util": "0.3.4",
-				"tslib": "^1.11.1"
+				"@firebase/util": "0.4.1",
+				"tslib": "^2.1.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"dev": true
+				}
 			}
 		},
 		"@firebase/remote-config-types": {
@@ -356,15 +657,44 @@
 			"dev": true
 		},
 		"@firebase/storage": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.4.2.tgz",
-			"integrity": "sha512-87CrvKrf8kijVekRBmUs8htsNz7N5X/pDhv3BvJBqw8K65GsUolpyjx0f4QJRkCRUYmh3MSkpa5P08lpVbC6nQ==",
+			"version": "0.0.900-exp.b0c8425bc",
+			"resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.0.900-exp.b0c8425bc.tgz",
+			"integrity": "sha512-e2m8zZ4PxT8nyoebp8dtWZJ8+8AfrMYKymhynHbxulzSS13XdhXpxy4N0N0z4pPfDWsyQxMfwlnzQo1QIU/Bhw==",
 			"dev": true,
 			"requires": {
-				"@firebase/component": "0.1.21",
+				"@firebase/component": "0.4.0",
 				"@firebase/storage-types": "0.3.13",
-				"@firebase/util": "0.3.4",
-				"tslib": "^1.11.1"
+				"@firebase/util": "0.4.1",
+				"tslib": "^2.1.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"dev": true
+				}
+			}
+		},
+		"@firebase/storage-compat": {
+			"version": "0.0.900-exp.b0c8425bc",
+			"resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.0.900-exp.b0c8425bc.tgz",
+			"integrity": "sha512-+muyCfG/nWFo4kg1bTq4Quau1EJ9wYsf6SCxJjTD96iozkuALnVwHpPFdr0k9/vJEo/4UNaRiIimVk35nKnlCw==",
+			"dev": true,
+			"requires": {
+				"@firebase/component": "0.4.0",
+				"@firebase/storage": "0.0.900-exp.b0c8425bc",
+				"@firebase/storage-types": "0.3.13",
+				"@firebase/util": "0.4.1",
+				"tslib": "^2.1.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"dev": true
+				}
 			}
 		},
 		"@firebase/storage-types": {
@@ -374,12 +704,20 @@
 			"dev": true
 		},
 		"@firebase/util": {
-			"version": "0.3.4",
-			"resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.3.4.tgz",
-			"integrity": "sha512-VwjJUE2Vgr2UMfH63ZtIX9Hd7x+6gayi6RUXaTqEYxSbf/JmehLmAEYSuxS/NckfzAXWeGnKclvnXVibDgpjQQ==",
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.4.1.tgz",
+			"integrity": "sha512-XhYCOwq4AH+YeQBEnDQvigz50WiiBU4LnJh2+//VMt4J2Ybsk0eTgUHNngUzXsmp80EJrwal3ItODg55q1ajWg==",
 			"dev": true,
 			"requires": {
-				"tslib": "^1.11.1"
+				"tslib": "^2.1.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"dev": true
+				}
 			}
 		},
 		"@firebase/webchannel-wrapper": {
@@ -389,9 +727,9 @@
 			"dev": true
 		},
 		"@grpc/grpc-js": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.2.8.tgz",
-			"integrity": "sha512-9C1xiCbnYe/3OFpSuRqz2JgFSOxv6+SlqFhXgRC1nHfXYbLnXvtmsI/NpaMs6k9ZNyV4gyaOOh5Z4McfegQGew==",
+			"version": "1.2.12",
+			"resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.2.12.tgz",
+			"integrity": "sha512-+gPCklP1eqIgrNPyzddYQdt9+GvZqPlLpIjIo+TveE+gbtp74VV1A2ju8ExeO8ma8f7MbpaGZx/KJPYVWL9eDw==",
 			"dev": true,
 			"requires": {
 				"@types/node": ">=12.12.47",
@@ -400,9 +738,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "14.14.30",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.30.tgz",
-					"integrity": "sha512-gUWhy8s45fQp4PqqKecsnOkdW0kt1IaKjgOIR3HPokkzTmQj9ji2wWFID5THu1MKrtO+d4s2lVrlEhXUsPXSvg==",
+					"version": "14.14.37",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.37.tgz",
+					"integrity": "sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==",
 					"dev": true
 				}
 			}
@@ -831,12 +1169,6 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
 		},
-		"core-js": {
-			"version": "3.6.5",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
-			"integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
-			"dev": true
-		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -1102,25 +1434,31 @@
 			}
 		},
 		"firebase": {
-			"version": "8.2.8",
-			"resolved": "https://registry.npmjs.org/firebase/-/firebase-8.2.8.tgz",
-			"integrity": "sha512-7DDqGHPvk6wKz0VNU5SjbKk1b2uecSLGoe06ClJqd/cxcRZGBOTyBiiUBgjcGHUuRlJEGUgv3zuDdvn/POMQlA==",
+			"version": "0.900.23",
+			"resolved": "https://registry.npmjs.org/firebase/-/firebase-0.900.23.tgz",
+			"integrity": "sha512-NL2cl8y1u/1IF5h5Ej4T+rlOnLyi66EXbWRt6uGnZTxII8k/lgYCNjfu4RnCB90HLI7qnknvcGQjYOHJQeqK1Q==",
 			"dev": true,
 			"requires": {
-				"@firebase/analytics": "0.6.3",
-				"@firebase/app": "0.6.14",
-				"@firebase/app-types": "0.6.1",
-				"@firebase/auth": "0.16.4",
-				"@firebase/database": "0.9.3",
-				"@firebase/firestore": "2.1.6",
-				"@firebase/functions": "0.6.1",
-				"@firebase/installations": "0.4.19",
-				"@firebase/messaging": "0.7.3",
-				"@firebase/performance": "0.4.5",
-				"@firebase/polyfill": "0.3.36",
-				"@firebase/remote-config": "0.1.30",
-				"@firebase/storage": "0.4.2",
-				"@firebase/util": "0.3.4"
+				"@firebase/analytics": "0.0.900-exp.b0c8425bc",
+				"@firebase/analytics-compat": "0.0.900-exp.b0c8425bc",
+				"@firebase/app": "0.0.900-exp.b0c8425bc",
+				"@firebase/app-compat": "0.0.900-exp.b0c8425bc",
+				"@firebase/auth": "0.0.900-exp.b0c8425bc",
+				"@firebase/auth-compat": "0.0.900-exp.b0c8425bc",
+				"@firebase/database": "0.0.900-exp.b0c8425bc",
+				"@firebase/database-compat": "0.0.900-exp.b0c8425bc",
+				"@firebase/firestore": "0.0.900-exp.b0c8425bc",
+				"@firebase/firestore-compat": "0.0.900-exp.b0c8425bc",
+				"@firebase/functions": "0.0.900-exp.b0c8425bc",
+				"@firebase/functions-compat": "0.0.900-exp.b0c8425bc",
+				"@firebase/messaging": "0.0.900-exp.b0c8425bc",
+				"@firebase/messaging-compat": "0.0.900-exp.b0c8425bc",
+				"@firebase/performance": "0.0.900-exp.b0c8425bc",
+				"@firebase/performance-compat": "0.0.900-exp.b0c8425bc",
+				"@firebase/remote-config": "0.0.900-exp.b0c8425bc",
+				"@firebase/remote-config-compat": "0.0.900-exp.b0c8425bc",
+				"@firebase/storage": "0.0.900-exp.b0c8425bc",
+				"@firebase/storage-compat": "0.0.900-exp.b0c8425bc"
 			}
 		},
 		"for-in": {
@@ -1179,9 +1517,9 @@
 			"dev": true
 		},
 		"gaxios": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.1.0.tgz",
-			"integrity": "sha512-vb0to8xzGnA2qcgywAjtshOKKVDf2eQhJoiL6fHhgW5tVN7wNk7egnYIO9zotfn3lQ3De1VPdf7V5/BWfCtCmg==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.2.0.tgz",
+			"integrity": "sha512-Ms7fNifGv0XVU+6eIyL9LB7RVESeML9+cMvkwGS70xyD6w2Z80wl6RiqiJ9k1KFlJCUTQqFFc8tXmPQfSKUe8g==",
 			"dev": true,
 			"requires": {
 				"abort-controller": "^3.0.0",
@@ -1200,11 +1538,6 @@
 				"gaxios": "^4.0.0",
 				"json-bigint": "^1.0.0"
 			}
-		},
-		"geofire-common": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/geofire-common/-/geofire-common-5.1.0.tgz",
-			"integrity": "sha512-zdVQ+QGfW6Edty/FplWANzh7M40LpagIgjHGk0mAuF58oXMosZmIYcGjmBwHoAsOCgZ1mlvTC7XvsBOYXDxAFA=="
 		},
 		"get-func-name": {
 			"version": "2.0.0",
@@ -1395,6 +1728,12 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/idb/-/idb-3.0.2.tgz",
 			"integrity": "sha512-+FLa/0sTXqyux0o6C+i2lOR0VoS60LU/jzUo5xjfY6+7sEEgy4Gz1O7yFBXvjd7N0NyIGWIRg8DcQSLEG+VSPw==",
+			"dev": true
+		},
+		"immediate": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+			"integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
 			"dev": true
 		},
 		"inflight": {
@@ -1682,6 +2021,18 @@
 				"verror": "1.10.0"
 			}
 		},
+		"jszip": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.6.0.tgz",
+			"integrity": "sha512-jgnQoG9LKnWO3mnVNBnfhkh0QknICd1FGSrXcgrl67zioyJ4wgx25o9ZqwNtrROSflGBCGYnJfjrIyRIby1OoQ==",
+			"dev": true,
+			"requires": {
+				"lie": "~3.3.0",
+				"pako": "~1.0.2",
+				"readable-stream": "~2.3.6",
+				"set-immediate-shim": "~1.0.1"
+			}
+		},
 		"jwa": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
@@ -1726,6 +2077,15 @@
 			"requires": {
 				"prelude-ls": "~1.1.2",
 				"type-check": "~0.3.2"
+			}
+		},
+		"lie": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+			"integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+			"dev": true,
+			"requires": {
+				"immediate": "~3.0.5"
 			}
 		},
 		"lodash": {
@@ -3004,6 +3364,12 @@
 				"word-wrap": "~1.2.3"
 			}
 		},
+		"pako": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+			"dev": true
+		},
 		"parse-glob": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
@@ -3064,10 +3430,10 @@
 			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
 			"dev": true
 		},
-		"promise-polyfill": {
-			"version": "8.1.3",
-			"resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.3.tgz",
-			"integrity": "sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g==",
+		"process-nextick-args": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
 			"dev": true
 		},
 		"protobufjs": {
@@ -3092,9 +3458,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "13.13.44",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.44.tgz",
-					"integrity": "sha512-SmWrt1iSL/O+62rWzhvGI508n7kFwpk7B7++rSqyx1RqkNRgWmJ+52Tlu7Cgb/KdCjgiMli37npNfO+tRlKk9w==",
+					"version": "13.13.48",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.48.tgz",
+					"integrity": "sha512-z8wvSsgWQzkr4sVuMEEOvwMdOQjiRY2Y/ZW4fDfjfe3+TfQrZqFKOthBgk2RnVEmtOKrkwdZ7uTvsxTBLjKGDQ==",
 					"dev": true
 				}
 			}
@@ -3138,6 +3504,29 @@
 					"version": "6.0.3",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
 					"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+					"dev": true
+				}
+			}
+		},
+		"readable-stream": {
+			"version": "2.3.7",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+			"dev": true,
+			"requires": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 					"dev": true
 				}
 			}
@@ -3225,6 +3614,31 @@
 			"requires": {
 				"is-core-module": "^2.2.0",
 				"path-parse": "^1.0.6"
+			}
+		},
+		"rimraf": {
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+			"dev": true,
+			"requires": {
+				"glob": "^7.1.3"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "7.1.6",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+					"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				}
 			}
 		},
 		"rollup": {
@@ -3357,6 +3771,26 @@
 				"xmlchars": "^2.1.1"
 			}
 		},
+		"selenium-webdriver": {
+			"version": "4.0.0-beta.1",
+			"resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.0.0-beta.1.tgz",
+			"integrity": "sha512-DJ10z6Yk+ZBaLrt1CLElytQ/FOayx29ANKDtmtyW1A6kCJx3+dsc5fFMOZxwzukDniyYsC3OObT5pUAsgkjpxQ==",
+			"dev": true,
+			"requires": {
+				"jszip": "^3.5.0",
+				"rimraf": "^2.7.1",
+				"tmp": "^0.2.1",
+				"ws": "^7.3.1"
+			},
+			"dependencies": {
+				"ws": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.4.tgz",
+					"integrity": "sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw==",
+					"dev": true
+				}
+			}
+		},
 		"semver": {
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -3367,6 +3801,12 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
 			"integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
+			"dev": true
+		},
+		"set-immediate-shim": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
 			"dev": true
 		},
 		"source-map": {
@@ -3420,6 +3860,23 @@
 			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
 			"dev": true
 		},
+		"string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "~5.1.0"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+					"dev": true
+				}
+			}
+		},
 		"supports-color": {
 			"version": "5.4.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
@@ -3434,6 +3891,40 @@
 			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
 			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
 			"dev": true
+		},
+		"tmp": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+			"integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+			"dev": true,
+			"requires": {
+				"rimraf": "^3.0.0"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "7.1.6",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+					"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"rimraf": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				}
+			}
 		},
 		"to-fast-properties": {
 			"version": "2.0.0",
@@ -3594,6 +4085,12 @@
 				"punycode": "^2.1.0"
 			}
 		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"dev": true
+		},
 		"uuid": {
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
@@ -3662,12 +4159,6 @@
 			"requires": {
 				"iconv-lite": "0.4.24"
 			}
-		},
-		"whatwg-fetch": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-			"integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
-			"dev": true
 		},
 		"whatwg-mimetype": {
 			"version": "2.3.0",

--- a/packages/geofire/package-lock.json
+++ b/packages/geofire/package-lock.json
@@ -124,15 +124,15 @@
 			}
 		},
 		"@firebase/analytics": {
-			"version": "0.0.900-exp.b0c8425bc",
-			"resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.0.900-exp.b0c8425bc.tgz",
-			"integrity": "sha512-QfgzaqsyftbZ21cPpCpHD/zQ45OCxT8tY0QK50nCUxXkJdKO9nk9Jot5LA3VFUcS6Qvo+fdcbC31Yg/y8xowXA==",
+			"version": "0.0.900-exp.894b5da5a",
+			"resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.0.900-exp.894b5da5a.tgz",
+			"integrity": "sha512-eECrPHZnn17n5SOv41zbvY5gETg6QYcFcAINgOekm0+uMRp1JciDOoGRtLFca6rR0dVII06zJh8mWyk6u+RCtQ==",
 			"dev": true,
 			"requires": {
-				"@firebase/component": "0.4.0",
-				"@firebase/installations": "0.0.900-exp.b0c8425bc",
+				"@firebase/component": "0.4.1",
+				"@firebase/installations": "0.0.900-exp.894b5da5a",
 				"@firebase/logger": "0.2.6",
-				"@firebase/util": "0.4.1",
+				"@firebase/util": "1.0.0",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -145,15 +145,15 @@
 			}
 		},
 		"@firebase/analytics-compat": {
-			"version": "0.0.900-exp.b0c8425bc",
-			"resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.0.900-exp.b0c8425bc.tgz",
-			"integrity": "sha512-UeOBK/f6RRezJCYGp7XFDowP8ezNCbJyg0Otyd3HByV1ZcIJn0Wnl80/iQ1Ybk9iN5hCIM9uyoYNnTe9ViKmag==",
+			"version": "0.0.900-exp.894b5da5a",
+			"resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.0.900-exp.894b5da5a.tgz",
+			"integrity": "sha512-WceCqszQxu0rBoGR9GqJQSI3Bhz6wLGBlJ+wPB0hswpYoOinZR7u/Oi9aS+mXAn5wKh5FvV6LHZpJQCPTQ70wg==",
 			"dev": true,
 			"requires": {
-				"@firebase/analytics": "0.0.900-exp.b0c8425bc",
+				"@firebase/analytics": "0.0.900-exp.894b5da5a",
 				"@firebase/analytics-types": "0.4.0",
-				"@firebase/component": "0.4.0",
-				"@firebase/util": "0.4.1",
+				"@firebase/component": "0.4.1",
+				"@firebase/util": "1.0.0",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -172,14 +172,14 @@
 			"dev": true
 		},
 		"@firebase/app": {
-			"version": "0.0.900-exp.b0c8425bc",
-			"resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.0.900-exp.b0c8425bc.tgz",
-			"integrity": "sha512-WvWPl2ZwzTHkwawuP9SL81S9ciDSlaEkdrfnc12ZrmQJVVZDHMUDkrmV4DMXcBKtYLO2JlJzmlCNKOEZwzHBdw==",
+			"version": "0.0.900-exp.894b5da5a",
+			"resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.0.900-exp.894b5da5a.tgz",
+			"integrity": "sha512-/xzLbH6349mBb+RCmXP8BkBA+wL+U3Rurb9dDGRrc3umMA3BJKTST/KSW5JJaixZ51Gil9vSF4g1ZQV0yYg9Yg==",
 			"dev": true,
 			"requires": {
-				"@firebase/component": "0.4.0",
+				"@firebase/component": "0.4.1",
 				"@firebase/logger": "0.2.6",
-				"@firebase/util": "0.4.1",
+				"@firebase/util": "1.0.0",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -192,15 +192,15 @@
 			}
 		},
 		"@firebase/app-compat": {
-			"version": "0.0.900-exp.b0c8425bc",
-			"resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.0.900-exp.b0c8425bc.tgz",
-			"integrity": "sha512-bSivtLuYVpP5mfftx7wTrBUgCbJD+K6BqYMF+gCj2C3c4KdAWnUJDdJhK9BELnbVzIY/N+L95RZn9XodmXKF+A==",
+			"version": "0.0.900-exp.894b5da5a",
+			"resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.0.900-exp.894b5da5a.tgz",
+			"integrity": "sha512-DVo9xK2bC2RJccoWlzbH0wJZgapVJ/zS/F69e5d1PtXjxzdtLAJMtaeA2kTY7UV8aZf6sE7Ahd68RCPZD2fI+w==",
 			"dev": true,
 			"requires": {
-				"@firebase/app": "0.0.900-exp.b0c8425bc",
-				"@firebase/component": "0.4.0",
+				"@firebase/app": "0.0.900-exp.894b5da5a",
+				"@firebase/component": "0.4.1",
 				"@firebase/logger": "0.2.6",
-				"@firebase/util": "0.4.1",
+				"@firebase/util": "1.0.0",
 				"dom-storage": "2.1.0",
 				"tslib": "^2.1.0",
 				"xmlhttprequest": "1.8.0"
@@ -220,14 +220,14 @@
 			"integrity": "sha512-L/ZnJRAq7F++utfuoTKX4CLBG5YR7tFO3PLzG1/oXXKEezJ0kRL3CMRoueBEmTCzVb/6SIs2Qlaw++uDgi5Xyg=="
 		},
 		"@firebase/auth": {
-			"version": "0.0.900-exp.b0c8425bc",
-			"resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.0.900-exp.b0c8425bc.tgz",
-			"integrity": "sha512-KNG8CQJ6t5EyBOMd5967DgaM0LYObN9Af39I3AF4KXLfAKJNQnqxPP5dGn01mWk3Em/xUF2uRKsnjWbKY5EnSQ==",
+			"version": "0.0.900-exp.894b5da5a",
+			"resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.0.900-exp.894b5da5a.tgz",
+			"integrity": "sha512-1z6+8GDqABujKRXeRBC4HdaTS/kn2A2k4wFxGn0YgaUJAnm3Znz4KSTqvg2mT82/GNnwBXhWgbjlmLt0vaVrvA==",
 			"dev": true,
 			"requires": {
-				"@firebase/component": "0.4.0",
+				"@firebase/component": "0.4.1",
 				"@firebase/logger": "0.2.6",
-				"@firebase/util": "0.4.1",
+				"@firebase/util": "1.0.0",
 				"node-fetch": "2.6.1",
 				"selenium-webdriver": "4.0.0-beta.1",
 				"tslib": "^2.1.0"
@@ -242,23 +242,42 @@
 			}
 		},
 		"@firebase/auth-compat": {
-			"version": "0.0.900-exp.b0c8425bc",
-			"resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.0.900-exp.b0c8425bc.tgz",
-			"integrity": "sha512-Ve6+sYwdQgCNljsCQ/IsDrYkvESG3+W5q1u+90RFPK6TzLnloRyY4ECD8RIAMleJBzFnwfhfACRBjR9qZixbFQ==",
+			"version": "0.0.900-exp.894b5da5a",
+			"resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.0.900-exp.894b5da5a.tgz",
+			"integrity": "sha512-g56ZU8pn7pY0IYHSvET8My9Q7wp//2bgTLdU9IuHxvmUy7v8pdpAKnpPkBu/tlAMK5MoV5vsxB21JuQBXuRp8A==",
 			"dev": true,
 			"requires": {
-				"@firebase/auth": "0.0.900-exp.b0c8425bc",
+				"@firebase/auth": "0.0.900-exp.894b5da5a",
 				"@firebase/auth-types": "0.10.2",
-				"@firebase/component": "0.4.0",
-				"@firebase/util": "0.4.1",
+				"@firebase/component": "0.4.1",
+				"@firebase/util": "1.0.0",
 				"node-fetch": "2.6.1",
+				"selenium-webdriver": "^4.0.0-beta.2",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
+				"selenium-webdriver": {
+					"version": "4.0.0-beta.3",
+					"resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.0.0-beta.3.tgz",
+					"integrity": "sha512-R0mGHpQkSKgIWiPgcKDcckh4A6aaK0KTyWxs5ieuiI7zsXQ+Kb6neph+dNoeqq3jSBGyv3ONo2w3oohoL4D/Rg==",
+					"dev": true,
+					"requires": {
+						"jszip": "^3.5.0",
+						"rimraf": "^2.7.1",
+						"tmp": "^0.2.1",
+						"ws": "^7.3.1"
+					}
+				},
 				"tslib": {
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
 					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"dev": true
+				},
+				"ws": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.4.tgz",
+					"integrity": "sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw==",
 					"dev": true
 				}
 			}
@@ -276,12 +295,12 @@
 			"dev": true
 		},
 		"@firebase/component": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.4.0.tgz",
-			"integrity": "sha512-L7kLKpW1v5qxPfIhx/VqHuVi+vr5IcnDS4zCJFb+/eYe23i6czSOWR1urAoJ4r42Dk0XB5kDt6Idojdd9BGMEA==",
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.4.1.tgz",
+			"integrity": "sha512-f0IbIsoe33QzOj554rmDL04PyeZX/nNZYOAwlTzKmHq/JoFN6YoySi+0ZLyCtFrnRgw6zNnR/POXKOdfljWqZA==",
 			"dev": true,
 			"requires": {
-				"@firebase/util": "0.4.1",
+				"@firebase/util": "1.0.0",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -294,16 +313,16 @@
 			}
 		},
 		"@firebase/database": {
-			"version": "0.0.900-exp.b0c8425bc",
-			"resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.0.900-exp.b0c8425bc.tgz",
-			"integrity": "sha512-GnEEqWZN4gc/plLEkkBOFkT984L/EfH8GIPfsaEqib1+1RJ7Pbh2vxXN3SHEoaODIh/VOCeQ36HM9Ip5/aTvHg==",
+			"version": "0.0.900-exp.894b5da5a",
+			"resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.0.900-exp.894b5da5a.tgz",
+			"integrity": "sha512-TAH6fn/9PwfeZS8ju0h14QzK8GbXGxrcup8qSeymTyS3Tklzo7hEWvlricnsx0f0oYwtXbW3WZEnfc2BaQLgOg==",
 			"dev": true,
 			"requires": {
 				"@firebase/auth-interop-types": "0.1.5",
-				"@firebase/component": "0.4.0",
-				"@firebase/database-types": "0.7.1",
+				"@firebase/component": "0.4.1",
+				"@firebase/database-types": "0.7.2",
 				"@firebase/logger": "0.2.6",
-				"@firebase/util": "0.4.1",
+				"@firebase/util": "1.0.0",
 				"faye-websocket": "0.11.3",
 				"tslib": "^2.1.0"
 			},
@@ -315,9 +334,9 @@
 					"dev": true
 				},
 				"@firebase/database-types": {
-					"version": "0.7.1",
-					"resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.7.1.tgz",
-					"integrity": "sha512-465ceJXSMqFFMnL2lxYx+YhYajcyk+VpGiXf9T6KNME0lKne5hYuqYr7XmS8/sTeyV0huhmTb8K1nxlA7hiPOg==",
+					"version": "0.7.2",
+					"resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.7.2.tgz",
+					"integrity": "sha512-cdAd/dgwvC0r3oLEDUR+ULs1vBsEvy0b27nlzKhU6LQgm9fCDzgaH9nFGv8x+S9dly4B0egAXkONkVoWcOAisg==",
 					"dev": true,
 					"requires": {
 						"@firebase/app-types": "0.6.2"
@@ -332,17 +351,17 @@
 			}
 		},
 		"@firebase/database-compat": {
-			"version": "0.0.900-exp.b0c8425bc",
-			"resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-0.0.900-exp.b0c8425bc.tgz",
-			"integrity": "sha512-s1lTGei5CN163b3qsAYOqclHzj7gbQbWxYJZE1YWO3TDOjYyHpElH93yfKl9LuAB2ptNf+WxZ2Z8Cppff9cAFQ==",
+			"version": "0.0.900-exp.894b5da5a",
+			"resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-0.0.900-exp.894b5da5a.tgz",
+			"integrity": "sha512-j/RYAsQISl2/m3QiSiWD8aa+8ryhjhu1km/Ts/dVf36owUix0XQ6gvL4PD23JO/WuRqEXpjeULK4S175aJBn/A==",
 			"dev": true,
 			"requires": {
 				"@firebase/auth-interop-types": "0.1.5",
-				"@firebase/component": "0.4.0",
-				"@firebase/database": "0.0.900-exp.b0c8425bc",
-				"@firebase/database-types": "0.7.1",
+				"@firebase/component": "0.4.1",
+				"@firebase/database": "0.0.900-exp.894b5da5a",
+				"@firebase/database-types": "0.7.2",
 				"@firebase/logger": "0.2.6",
-				"@firebase/util": "0.4.1",
+				"@firebase/util": "1.0.0",
 				"faye-websocket": "0.11.3",
 				"tslib": "^2.1.0"
 			},
@@ -354,9 +373,9 @@
 					"dev": true
 				},
 				"@firebase/database-types": {
-					"version": "0.7.1",
-					"resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.7.1.tgz",
-					"integrity": "sha512-465ceJXSMqFFMnL2lxYx+YhYajcyk+VpGiXf9T6KNME0lKne5hYuqYr7XmS8/sTeyV0huhmTb8K1nxlA7hiPOg==",
+					"version": "0.7.2",
+					"resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.7.2.tgz",
+					"integrity": "sha512-cdAd/dgwvC0r3oLEDUR+ULs1vBsEvy0b27nlzKhU6LQgm9fCDzgaH9nFGv8x+S9dly4B0egAXkONkVoWcOAisg==",
 					"dev": true,
 					"requires": {
 						"@firebase/app-types": "0.6.2"
@@ -379,15 +398,15 @@
 			}
 		},
 		"@firebase/firestore": {
-			"version": "0.0.900-exp.b0c8425bc",
-			"resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-0.0.900-exp.b0c8425bc.tgz",
-			"integrity": "sha512-XZZYA/oe2nTMf1GWoPcH5BPYbz6BgBpXm89In4zkx6jKVh944/wuQRCZEuR93AOJLeRDJw/4ZskqES8G0GTqXA==",
+			"version": "0.0.900-exp.894b5da5a",
+			"resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-0.0.900-exp.894b5da5a.tgz",
+			"integrity": "sha512-aMCoGe1rN5ChmGgBU3GCqDWTG8GtbGrHq8wRmQGUrh90TDG4DX1ImF5xyJrymwST1juMk8kVtV1okvQ1zmPf8A==",
 			"dev": true,
 			"requires": {
-				"@firebase/component": "0.4.0",
+				"@firebase/component": "0.4.1",
 				"@firebase/firestore-types": "2.2.0",
 				"@firebase/logger": "0.2.6",
-				"@firebase/util": "0.4.1",
+				"@firebase/util": "1.0.0",
 				"@firebase/webchannel-wrapper": "0.4.1",
 				"@grpc/grpc-js": "^1.0.0",
 				"@grpc/proto-loader": "^0.5.0",
@@ -404,16 +423,16 @@
 			}
 		},
 		"@firebase/firestore-compat": {
-			"version": "0.0.900-exp.b0c8425bc",
-			"resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.0.900-exp.b0c8425bc.tgz",
-			"integrity": "sha512-H0IUTWK4A3s2V6eBpnxF9w+0kuBQU18lzfkxHKayoAXHNoXb3vjiC0RHVjY8eY0ahHW90+nDqFIXaJ/Z7EteQw==",
+			"version": "0.0.900-exp.894b5da5a",
+			"resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.0.900-exp.894b5da5a.tgz",
+			"integrity": "sha512-CjT+5wp3jyJwUWI8hKhlg7WxpbLToHbBm9BF9BpihDY1j0IyJmBICC0LJEtXsib/IOPIsf04rxUiFHKX4ciOHg==",
 			"dev": true,
 			"requires": {
-				"@firebase/component": "0.4.0",
-				"@firebase/firestore": "0.0.900-exp.b0c8425bc",
+				"@firebase/component": "0.4.1",
+				"@firebase/firestore": "0.0.900-exp.894b5da5a",
 				"@firebase/firestore-types": "2.2.0",
 				"@firebase/logger": "0.2.6",
-				"@firebase/util": "0.4.1",
+				"@firebase/util": "1.0.0",
 				"@firebase/webchannel-wrapper": "0.4.1",
 				"@grpc/grpc-js": "^1.0.0",
 				"@grpc/proto-loader": "^0.5.0",
@@ -436,14 +455,14 @@
 			"dev": true
 		},
 		"@firebase/functions": {
-			"version": "0.0.900-exp.b0c8425bc",
-			"resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.0.900-exp.b0c8425bc.tgz",
-			"integrity": "sha512-7YZMEMr+xCgSUWWBbampEjl+w+ZR2yuhAIFD/p8TqGfKOQWNQciwNvqOX/+qG+SqjDmPb+p+/3LFvxQT68YSyA==",
+			"version": "0.0.900-exp.894b5da5a",
+			"resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.0.900-exp.894b5da5a.tgz",
+			"integrity": "sha512-7094mgWbVsMLaeKalQkEVvaydS+l1f/gytFXYyz+qtazYvghsrQd+n5pJQBzbBVNHw2NAQrJxHrePCftw8u2jg==",
 			"dev": true,
 			"requires": {
-				"@firebase/component": "0.4.0",
+				"@firebase/component": "0.4.1",
 				"@firebase/messaging-types": "0.5.0",
-				"@firebase/util": "0.4.1",
+				"@firebase/util": "1.0.0",
 				"node-fetch": "2.6.1",
 				"tslib": "^2.1.0"
 			},
@@ -457,16 +476,16 @@
 			}
 		},
 		"@firebase/functions-compat": {
-			"version": "0.0.900-exp.b0c8425bc",
-			"resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.0.900-exp.b0c8425bc.tgz",
-			"integrity": "sha512-6lCfY6cX6aFgbkVrnSd/zF9gYRo44eDQz/DGtOttkShdWkoOQrct4yAN044VAxZJ2A1vcM1mq2WCLlYLq3AEAw==",
+			"version": "0.0.900-exp.894b5da5a",
+			"resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.0.900-exp.894b5da5a.tgz",
+			"integrity": "sha512-M57QEQ8TN12lYEMJZ3anaRGILJ59nOU4Xp6cCHsAbB5DkYLuxoHccvfZCzwmv95hEhF1mSvFPrZRJG9F3PVmZg==",
 			"dev": true,
 			"requires": {
-				"@firebase/component": "0.4.0",
-				"@firebase/functions": "0.0.900-exp.b0c8425bc",
+				"@firebase/component": "0.4.1",
+				"@firebase/functions": "0.0.900-exp.894b5da5a",
 				"@firebase/functions-types": "0.4.0",
 				"@firebase/messaging-types": "0.5.0",
-				"@firebase/util": "0.4.1",
+				"@firebase/util": "1.0.0",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -485,13 +504,13 @@
 			"dev": true
 		},
 		"@firebase/installations": {
-			"version": "0.0.900-exp.b0c8425bc",
-			"resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.0.900-exp.b0c8425bc.tgz",
-			"integrity": "sha512-XsYWVbKQdP4WmMYAIMTk6A3inv1jHBxDXgtReQ58WH1GrVwyNSoACpJK/TzIAeOugRSARkcF5f2E0yoVujBZog==",
+			"version": "0.0.900-exp.894b5da5a",
+			"resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.0.900-exp.894b5da5a.tgz",
+			"integrity": "sha512-mKjQq3etoZdZVCfUap+2tJgqS6AFHptg5HUBmUVGn+5Nz74i4n8M/M4W/qhXIjlnEcdLGop+5XaE9Tm03tbC7Q==",
 			"dev": true,
 			"requires": {
-				"@firebase/component": "0.4.0",
-				"@firebase/util": "0.4.1",
+				"@firebase/component": "0.4.1",
+				"@firebase/util": "1.0.0",
 				"idb": "3.0.2",
 				"tslib": "^2.1.0"
 			},
@@ -511,14 +530,14 @@
 			"dev": true
 		},
 		"@firebase/messaging": {
-			"version": "0.0.900-exp.b0c8425bc",
-			"resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.0.900-exp.b0c8425bc.tgz",
-			"integrity": "sha512-HOrZHjPGqLgQAl/5BDICN6KjExL+Ap7NTAyN9DvQxCO6WLt+hacgJR7XXuqsr2a/teB6INh5qnmOPC/DCy7fog==",
+			"version": "0.0.900-exp.894b5da5a",
+			"resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.0.900-exp.894b5da5a.tgz",
+			"integrity": "sha512-Bvg5Fr0i9tkwYT+mANggr8IzGH+IoPR7u11ZWOp4Iwo3gVgH2Q2kaDHBxxaV07k33Vqs4xCGq+f5sc56yI9GUQ==",
 			"dev": true,
 			"requires": {
-				"@firebase/component": "0.4.0",
-				"@firebase/installations": "0.0.900-exp.b0c8425bc",
-				"@firebase/util": "0.4.1",
+				"@firebase/component": "0.4.1",
+				"@firebase/installations": "0.0.900-exp.894b5da5a",
+				"@firebase/util": "1.0.0",
 				"idb": "3.0.2",
 				"tslib": "^2.1.0"
 			},
@@ -532,15 +551,15 @@
 			}
 		},
 		"@firebase/messaging-compat": {
-			"version": "0.0.900-exp.b0c8425bc",
-			"resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.0.900-exp.b0c8425bc.tgz",
-			"integrity": "sha512-beNO8moaXJaLGsn1xL14urNN87p1PRTr924bSHNJ77dCF7EYHJZz8q+goegbO/fFa6SDplKzSexSOgSEGMagGQ==",
+			"version": "0.0.900-exp.894b5da5a",
+			"resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.0.900-exp.894b5da5a.tgz",
+			"integrity": "sha512-LkkaK7KFj4xQhJS/ihFlHZfofgSYPWtHuCKv+vC8ANhl0BB4GMPU5huQ9sHLlQQxnmRViemXdphKNDceEnOzhQ==",
 			"dev": true,
 			"requires": {
-				"@firebase/component": "0.4.0",
-				"@firebase/installations": "0.0.900-exp.b0c8425bc",
-				"@firebase/messaging": "0.0.900-exp.b0c8425bc",
-				"@firebase/util": "0.4.1",
+				"@firebase/component": "0.4.1",
+				"@firebase/installations": "0.0.900-exp.894b5da5a",
+				"@firebase/messaging": "0.0.900-exp.894b5da5a",
+				"@firebase/util": "1.0.0",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -559,15 +578,15 @@
 			"dev": true
 		},
 		"@firebase/performance": {
-			"version": "0.0.900-exp.b0c8425bc",
-			"resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.0.900-exp.b0c8425bc.tgz",
-			"integrity": "sha512-DLrf8k1F7kUJ6WrrojwiHAxLw9D8SD7znxaJ7UejYUqhnJGs8CeHHuHfKHUfnm5462CLBUYRUpXOFVVV9TaCHQ==",
+			"version": "0.0.900-exp.894b5da5a",
+			"resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.0.900-exp.894b5da5a.tgz",
+			"integrity": "sha512-AObB2165d+DDuCN1p0wzJisA6CPqnDeZKnFOcOuMsVnQjRCC1smIDomXoDcNCh+9nEkz6MrGPZnhGgN5OGzT1Q==",
 			"dev": true,
 			"requires": {
-				"@firebase/component": "0.4.0",
-				"@firebase/installations": "0.0.900-exp.b0c8425bc",
+				"@firebase/component": "0.4.1",
+				"@firebase/installations": "0.0.900-exp.894b5da5a",
 				"@firebase/logger": "0.2.6",
-				"@firebase/util": "0.4.1",
+				"@firebase/util": "1.0.0",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -580,16 +599,16 @@
 			}
 		},
 		"@firebase/performance-compat": {
-			"version": "0.0.900-exp.b0c8425bc",
-			"resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.0.900-exp.b0c8425bc.tgz",
-			"integrity": "sha512-Z9fTL+2dQGjeAgPFuHz0DRwnm1SZdAhhJb35pDX48TmOchtVpviLXVEzgLb/1zfAlyyB6QwTcboInmvMNqgh2A==",
+			"version": "0.0.900-exp.894b5da5a",
+			"resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.0.900-exp.894b5da5a.tgz",
+			"integrity": "sha512-x4MiVQNYin4h90IoGOYkgWFSwH40u3M0YOx+YlBp0l+cKO74s9Rm0DVVNjVz3DZPC3WI1QCT2ImYiszJhQgwTg==",
 			"dev": true,
 			"requires": {
-				"@firebase/component": "0.4.0",
+				"@firebase/component": "0.4.1",
 				"@firebase/logger": "0.2.6",
-				"@firebase/performance": "0.0.900-exp.b0c8425bc",
+				"@firebase/performance": "0.0.900-exp.894b5da5a",
 				"@firebase/performance-types": "0.0.13",
-				"@firebase/util": "0.4.1",
+				"@firebase/util": "1.0.0",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -608,15 +627,15 @@
 			"dev": true
 		},
 		"@firebase/remote-config": {
-			"version": "0.0.900-exp.b0c8425bc",
-			"resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.0.900-exp.b0c8425bc.tgz",
-			"integrity": "sha512-CjpNgnN+OyX23KrKs/H/OS8AzGnIopzv3khSLfRydC9qjs1UARt/bAd1TGN7b/pwvA+OGHeal3AHJhgbmxp9kg==",
+			"version": "0.0.900-exp.894b5da5a",
+			"resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.0.900-exp.894b5da5a.tgz",
+			"integrity": "sha512-+5rO3r8zLDufpt1VO6Urm4/YluAYkvITpwzGPA+vv7a+Bs5P+Et4Z1bleUjSdlqJAZMpGnx748+AZYXiVxBtgQ==",
 			"dev": true,
 			"requires": {
-				"@firebase/component": "0.4.0",
-				"@firebase/installations": "0.0.900-exp.b0c8425bc",
+				"@firebase/component": "0.4.1",
+				"@firebase/installations": "0.0.900-exp.894b5da5a",
 				"@firebase/logger": "0.2.6",
-				"@firebase/util": "0.4.1",
+				"@firebase/util": "1.0.0",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -629,16 +648,16 @@
 			}
 		},
 		"@firebase/remote-config-compat": {
-			"version": "0.0.900-exp.b0c8425bc",
-			"resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.0.900-exp.b0c8425bc.tgz",
-			"integrity": "sha512-QcuaxoXicecffLiXzyS09P0f1ufZ7JU/WhiTGgXCOQ+EQMuAefqYQNNixxtWVSKC/LCEd+BhEH76vMh2TAKwFw==",
+			"version": "0.0.900-exp.894b5da5a",
+			"resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.0.900-exp.894b5da5a.tgz",
+			"integrity": "sha512-o78QgpipoRG/XiuzIGGgVX1PZS6xF4FPaQXbANtE+qdNJUpVfBVk6WpzeDlRE4c1h/EAJJi3fL4RZRmyy/b/WQ==",
 			"dev": true,
 			"requires": {
-				"@firebase/component": "0.4.0",
+				"@firebase/component": "0.4.1",
 				"@firebase/logger": "0.2.6",
-				"@firebase/remote-config": "0.0.900-exp.b0c8425bc",
+				"@firebase/remote-config": "0.0.900-exp.894b5da5a",
 				"@firebase/remote-config-types": "0.1.9",
-				"@firebase/util": "0.4.1",
+				"@firebase/util": "1.0.0",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -657,14 +676,14 @@
 			"dev": true
 		},
 		"@firebase/storage": {
-			"version": "0.0.900-exp.b0c8425bc",
-			"resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.0.900-exp.b0c8425bc.tgz",
-			"integrity": "sha512-e2m8zZ4PxT8nyoebp8dtWZJ8+8AfrMYKymhynHbxulzSS13XdhXpxy4N0N0z4pPfDWsyQxMfwlnzQo1QIU/Bhw==",
+			"version": "0.0.900-exp.894b5da5a",
+			"resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.0.900-exp.894b5da5a.tgz",
+			"integrity": "sha512-ECz2F9m3rUMutsnlx5Uv3mTQgXva5Q4PFNjkrE8c5d8VHfyl6dPxjBIbqK0Qi+QiFUfnWj7zyVyn5f9ADpIa8Q==",
 			"dev": true,
 			"requires": {
-				"@firebase/component": "0.4.0",
-				"@firebase/storage-types": "0.3.13",
-				"@firebase/util": "0.4.1",
+				"@firebase/component": "0.4.1",
+				"@firebase/storage-types": "0.4.0",
+				"@firebase/util": "1.0.0",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -677,15 +696,15 @@
 			}
 		},
 		"@firebase/storage-compat": {
-			"version": "0.0.900-exp.b0c8425bc",
-			"resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.0.900-exp.b0c8425bc.tgz",
-			"integrity": "sha512-+muyCfG/nWFo4kg1bTq4Quau1EJ9wYsf6SCxJjTD96iozkuALnVwHpPFdr0k9/vJEo/4UNaRiIimVk35nKnlCw==",
+			"version": "0.0.900-exp.894b5da5a",
+			"resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.0.900-exp.894b5da5a.tgz",
+			"integrity": "sha512-cmMZzwxv0eTEjanXjt6tjGTAQ+MaZpmNtC0c5vG9ZZI53kCnyCtljfnAtIaCYdJvc4BMsXEsdm0shYQ7R8JTQw==",
 			"dev": true,
 			"requires": {
-				"@firebase/component": "0.4.0",
-				"@firebase/storage": "0.0.900-exp.b0c8425bc",
-				"@firebase/storage-types": "0.3.13",
-				"@firebase/util": "0.4.1",
+				"@firebase/component": "0.4.1",
+				"@firebase/storage": "0.0.900-exp.894b5da5a",
+				"@firebase/storage-types": "0.4.0",
+				"@firebase/util": "1.0.0",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -698,15 +717,15 @@
 			}
 		},
 		"@firebase/storage-types": {
-			"version": "0.3.13",
-			"resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.3.13.tgz",
-			"integrity": "sha512-pL7b8d5kMNCCL0w9hF7pr16POyKkb3imOW7w0qYrhBnbyJTdVxMWZhb0HxCFyQWC0w3EiIFFmxoz8NTFZDEFog==",
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.4.0.tgz",
+			"integrity": "sha512-2xgiLGfDv6Fz5qRrsO47/7PfbV9P+5tEuvEktJYTNxrgTxGPj3sMb7ZkycIb4JE98fAbmGEeMQaRSorqR5bEIQ==",
 			"dev": true
 		},
 		"@firebase/util": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.4.1.tgz",
-			"integrity": "sha512-XhYCOwq4AH+YeQBEnDQvigz50WiiBU4LnJh2+//VMt4J2Ybsk0eTgUHNngUzXsmp80EJrwal3ItODg55q1ajWg==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.0.0.tgz",
+			"integrity": "sha512-KIEyuyrYKKtit+lAl66c2GVvooM1Pb+Yw/9yuSga1HKYMxNZwSsIMXU8X97sLZf7WJaanV1XNJEMkZTw3xKEoA==",
 			"dev": true,
 			"requires": {
 				"tslib": "^2.1.0"
@@ -1434,31 +1453,31 @@
 			}
 		},
 		"firebase": {
-			"version": "0.900.23",
-			"resolved": "https://registry.npmjs.org/firebase/-/firebase-0.900.23.tgz",
-			"integrity": "sha512-NL2cl8y1u/1IF5h5Ej4T+rlOnLyi66EXbWRt6uGnZTxII8k/lgYCNjfu4RnCB90HLI7qnknvcGQjYOHJQeqK1Q==",
+			"version": "9.0.0-beta.1",
+			"resolved": "https://registry.npmjs.org/firebase/-/firebase-9.0.0-beta.1.tgz",
+			"integrity": "sha512-dYPrlGUi+JYqQIydE4LGZ7A2X5uFazwUNbAX0s7N1S34swvgp5Xz2ww63DB+hwjglF6eH+PiMGBDSZSG7hikUw==",
 			"dev": true,
 			"requires": {
-				"@firebase/analytics": "0.0.900-exp.b0c8425bc",
-				"@firebase/analytics-compat": "0.0.900-exp.b0c8425bc",
-				"@firebase/app": "0.0.900-exp.b0c8425bc",
-				"@firebase/app-compat": "0.0.900-exp.b0c8425bc",
-				"@firebase/auth": "0.0.900-exp.b0c8425bc",
-				"@firebase/auth-compat": "0.0.900-exp.b0c8425bc",
-				"@firebase/database": "0.0.900-exp.b0c8425bc",
-				"@firebase/database-compat": "0.0.900-exp.b0c8425bc",
-				"@firebase/firestore": "0.0.900-exp.b0c8425bc",
-				"@firebase/firestore-compat": "0.0.900-exp.b0c8425bc",
-				"@firebase/functions": "0.0.900-exp.b0c8425bc",
-				"@firebase/functions-compat": "0.0.900-exp.b0c8425bc",
-				"@firebase/messaging": "0.0.900-exp.b0c8425bc",
-				"@firebase/messaging-compat": "0.0.900-exp.b0c8425bc",
-				"@firebase/performance": "0.0.900-exp.b0c8425bc",
-				"@firebase/performance-compat": "0.0.900-exp.b0c8425bc",
-				"@firebase/remote-config": "0.0.900-exp.b0c8425bc",
-				"@firebase/remote-config-compat": "0.0.900-exp.b0c8425bc",
-				"@firebase/storage": "0.0.900-exp.b0c8425bc",
-				"@firebase/storage-compat": "0.0.900-exp.b0c8425bc"
+				"@firebase/analytics": "0.0.900-exp.894b5da5a",
+				"@firebase/analytics-compat": "0.0.900-exp.894b5da5a",
+				"@firebase/app": "0.0.900-exp.894b5da5a",
+				"@firebase/app-compat": "0.0.900-exp.894b5da5a",
+				"@firebase/auth": "0.0.900-exp.894b5da5a",
+				"@firebase/auth-compat": "0.0.900-exp.894b5da5a",
+				"@firebase/database": "0.0.900-exp.894b5da5a",
+				"@firebase/database-compat": "0.0.900-exp.894b5da5a",
+				"@firebase/firestore": "0.0.900-exp.894b5da5a",
+				"@firebase/firestore-compat": "0.0.900-exp.894b5da5a",
+				"@firebase/functions": "0.0.900-exp.894b5da5a",
+				"@firebase/functions-compat": "0.0.900-exp.894b5da5a",
+				"@firebase/messaging": "0.0.900-exp.894b5da5a",
+				"@firebase/messaging-compat": "0.0.900-exp.894b5da5a",
+				"@firebase/performance": "0.0.900-exp.894b5da5a",
+				"@firebase/performance-compat": "0.0.900-exp.894b5da5a",
+				"@firebase/remote-config": "0.0.900-exp.894b5da5a",
+				"@firebase/remote-config-compat": "0.0.900-exp.894b5da5a",
+				"@firebase/storage": "0.0.900-exp.894b5da5a",
+				"@firebase/storage-compat": "0.0.900-exp.894b5da5a"
 			}
 		},
 		"for-in": {

--- a/packages/geofire/package-lock.json
+++ b/packages/geofire/package-lock.json
@@ -1903,27 +1903,6 @@
 				"semver": "^6.0.0"
 			}
 		},
-		"jest-worker": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.9.0.tgz",
-			"integrity": "sha512-51PE4haMSXcHohnSMdM42anbvZANYTqMrr52tVKPqqsPJMzoP6FYYDVqahX/HrAoKEKz3uUPzSvKs9A3qR4iVw==",
-			"dev": true,
-			"requires": {
-				"merge-stream": "^2.0.0",
-				"supports-color": "^6.1.0"
-			},
-			"dependencies": {
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
-			}
-		},
 		"js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3527,6 +3506,15 @@
 				}
 			}
 		},
+		"randombytes": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "^5.1.0"
+			}
+		},
 		"readable-stream": {
 			"version": "2.3.7",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -3703,6 +3691,55 @@
 				"resolve": "^1.10.0"
 			}
 		},
+		"rollup-plugin-terser": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-6.1.0.tgz",
+			"integrity": "sha512-4fB3M9nuoWxrwm39habpd4hvrbrde2W2GG4zEGPQg1YITNkM3Tqur5jSuXlWNzbv/2aMLJ+dZJaySc3GCD8oDw==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.8.3",
+				"jest-worker": "^26.0.0",
+				"serialize-javascript": "^3.0.0",
+				"terser": "^4.7.0"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"jest-worker": {
+					"version": "26.6.2",
+					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
+					"integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
+					"dev": true,
+					"requires": {
+						"@types/node": "*",
+						"merge-stream": "^2.0.0",
+						"supports-color": "^7.0.0"
+					}
+				},
+				"serialize-javascript": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-3.1.0.tgz",
+					"integrity": "sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==",
+					"dev": true,
+					"requires": {
+						"randombytes": "^2.1.0"
+					}
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
 		"rollup-plugin-typescript2": {
 			"version": "0.19.3",
 			"resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.19.3.tgz",
@@ -3746,18 +3783,6 @@
 					"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
 					"dev": true
 				}
-			}
-		},
-		"rollup-plugin-uglify": {
-			"version": "6.0.4",
-			"resolved": "https://registry.npmjs.org/rollup-plugin-uglify/-/rollup-plugin-uglify-6.0.4.tgz",
-			"integrity": "sha512-ddgqkH02klveu34TF0JqygPwZnsbhHVI6t8+hGTcYHngPkQb5MIHI0XiztXIN/d6V9j+efwHAqEL7LspSxQXGw==",
-			"dev": true,
-			"requires": {
-				"@babel/code-frame": "^7.0.0",
-				"jest-worker": "^24.0.0",
-				"serialize-javascript": "^2.1.2",
-				"uglify-js": "^3.4.9"
 			}
 		},
 		"rollup-pluginutils": {
@@ -3814,12 +3839,6 @@
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
 			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-			"dev": true
-		},
-		"serialize-javascript": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
-			"integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
 			"dev": true
 		},
 		"set-immediate-shim": {
@@ -3910,6 +3929,25 @@
 			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
 			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
 			"dev": true
+		},
+		"terser": {
+			"version": "4.8.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
+			"integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
+			"dev": true,
+			"requires": {
+				"commander": "^2.20.0",
+				"source-map": "~0.6.1",
+				"source-map-support": "~0.5.12"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+					"dev": true
+				}
+			}
 		},
 		"tmp": {
 			"version": "0.2.1",
@@ -4081,12 +4119,6 @@
 			"version": "3.9.9",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
 			"integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==",
-			"dev": true
-		},
-		"uglify-js": {
-			"version": "3.12.8",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.8.tgz",
-			"integrity": "sha512-fvBeuXOsvqjecUtF/l1dwsrrf5y2BCUk9AOJGzGcm6tE7vegku5u/YvqjyDaAGr422PLoLnrxg3EnRvTqsdC1w==",
 			"dev": true
 		},
 		"universalify": {

--- a/packages/geofire/package-lock.json
+++ b/packages/geofire/package-lock.json
@@ -124,92 +124,145 @@
 			}
 		},
 		"@firebase/analytics": {
-			"version": "0.0.900-exp.894b5da5a",
-			"resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.0.900-exp.894b5da5a.tgz",
-			"integrity": "sha512-eECrPHZnn17n5SOv41zbvY5gETg6QYcFcAINgOekm0+uMRp1JciDOoGRtLFca6rR0dVII06zJh8mWyk6u+RCtQ==",
+			"version": "0.7.11",
+			"resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.7.11.tgz",
+			"integrity": "sha512-rEGBmZdvD+biSAcMztrIftc/vS8Wgexau8Ok2aFqo3n3IkKDdBq2tdhh6tXsugBt755+q56HGQOHRWboaqG3LQ==",
 			"dev": true,
 			"requires": {
-				"@firebase/component": "0.4.1",
-				"@firebase/installations": "0.0.900-exp.894b5da5a",
-				"@firebase/logger": "0.2.6",
-				"@firebase/util": "1.0.0",
+				"@firebase/component": "0.5.16",
+				"@firebase/installations": "0.5.11",
+				"@firebase/logger": "0.3.3",
+				"@firebase/util": "1.6.2",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 					"dev": true
 				}
 			}
 		},
 		"@firebase/analytics-compat": {
-			"version": "0.0.900-exp.894b5da5a",
-			"resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.0.900-exp.894b5da5a.tgz",
-			"integrity": "sha512-WceCqszQxu0rBoGR9GqJQSI3Bhz6wLGBlJ+wPB0hswpYoOinZR7u/Oi9aS+mXAn5wKh5FvV6LHZpJQCPTQ70wg==",
+			"version": "0.1.12",
+			"resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.1.12.tgz",
+			"integrity": "sha512-mXR02p/4C9Xx07prhzr9nwocH6Xn3vpcO7DMGUMNB0qKdJADOaBow6LDlDY3u8ILhmHqNS8qPY3sKnhoTWzz8A==",
 			"dev": true,
 			"requires": {
-				"@firebase/analytics": "0.0.900-exp.894b5da5a",
-				"@firebase/analytics-types": "0.4.0",
-				"@firebase/component": "0.4.1",
-				"@firebase/util": "1.0.0",
+				"@firebase/analytics": "0.7.11",
+				"@firebase/analytics-types": "0.7.0",
+				"@firebase/component": "0.5.16",
+				"@firebase/util": "1.6.2",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 					"dev": true
 				}
 			}
 		},
 		"@firebase/analytics-types": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.4.0.tgz",
-			"integrity": "sha512-Jj2xW+8+8XPfWGkv9HPv/uR+Qrmq37NPYT352wf7MvE9LrstpLVmFg3LqG6MCRr5miLAom5sen2gZ+iOhVDeRA==",
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.7.0.tgz",
+			"integrity": "sha512-DNE2Waiwy5+zZnCfintkDtBfaW6MjIG883474v6Z0K1XZIvl76cLND4iv0YUb48leyF+PJK1KO2XrgHb/KpmhQ==",
 			"dev": true
 		},
 		"@firebase/app": {
-			"version": "0.0.900-exp.894b5da5a",
-			"resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.0.900-exp.894b5da5a.tgz",
-			"integrity": "sha512-/xzLbH6349mBb+RCmXP8BkBA+wL+U3Rurb9dDGRrc3umMA3BJKTST/KSW5JJaixZ51Gil9vSF4g1ZQV0yYg9Yg==",
+			"version": "0.7.27",
+			"resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.7.27.tgz",
+			"integrity": "sha512-gLxy9wHymCsPAWuIWg2S/gOWoAN/Nbpto+IWSXPHzjVUtPRvmuBrr9rvh8D2V2zHxNb1WigoZVLy5acRAf2rHg==",
 			"dev": true,
 			"requires": {
-				"@firebase/component": "0.4.1",
-				"@firebase/logger": "0.2.6",
-				"@firebase/util": "1.0.0",
+				"@firebase/component": "0.5.16",
+				"@firebase/logger": "0.3.3",
+				"@firebase/util": "1.6.2",
+				"idb": "7.0.1",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 					"dev": true
 				}
 			}
 		},
-		"@firebase/app-compat": {
-			"version": "0.0.900-exp.894b5da5a",
-			"resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.0.900-exp.894b5da5a.tgz",
-			"integrity": "sha512-DVo9xK2bC2RJccoWlzbH0wJZgapVJ/zS/F69e5d1PtXjxzdtLAJMtaeA2kTY7UV8aZf6sE7Ahd68RCPZD2fI+w==",
+		"@firebase/app-check": {
+			"version": "0.5.10",
+			"resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.5.10.tgz",
+			"integrity": "sha512-q/rpvhPBU7utREWTlsw+Nr9aZAHKZieF9o/6EJkymqFvWDDmvN+hycKidKWwJ2OcnUYjOr7GuvWUEAfw8X8/tQ==",
 			"dev": true,
 			"requires": {
-				"@firebase/app": "0.0.900-exp.894b5da5a",
-				"@firebase/component": "0.4.1",
-				"@firebase/logger": "0.2.6",
-				"@firebase/util": "1.0.0",
-				"dom-storage": "2.1.0",
-				"tslib": "^2.1.0",
-				"xmlhttprequest": "1.8.0"
+				"@firebase/component": "0.5.16",
+				"@firebase/logger": "0.3.3",
+				"@firebase/util": "1.6.2",
+				"tslib": "^2.1.0"
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+					"dev": true
+				}
+			}
+		},
+		"@firebase/app-check-compat": {
+			"version": "0.2.10",
+			"resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.2.10.tgz",
+			"integrity": "sha512-NNxroiY3BVaEGkKs8W4dzv2WnJ4PbeBL7DpF1MlRHEZHa/48YPZv8xKx3QcKbH0T+31s7ponPYnRYsNY+j4CaA==",
+			"dev": true,
+			"requires": {
+				"@firebase/app-check": "0.5.10",
+				"@firebase/app-check-types": "0.4.0",
+				"@firebase/component": "0.5.16",
+				"@firebase/logger": "0.3.3",
+				"@firebase/util": "1.6.2",
+				"tslib": "^2.1.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+					"dev": true
+				}
+			}
+		},
+		"@firebase/app-check-interop-types": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.1.0.tgz",
+			"integrity": "sha512-uZfn9s4uuRsaX5Lwx+gFP3B6YsyOKUE+Rqa6z9ojT4VSRAsZFko9FRn6OxQUA1z5t5d08fY4pf+/+Dkd5wbdbA==",
+			"dev": true
+		},
+		"@firebase/app-check-types": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.4.0.tgz",
+			"integrity": "sha512-SsWafqMABIOu7zLgWbmwvHGOeQQVQlwm42kwwubsmfLmL4Sf5uGpBfDhQ0CAkpi7bkJ/NwNFKafNDL9prRNP0Q==",
+			"dev": true
+		},
+		"@firebase/app-compat": {
+			"version": "0.1.28",
+			"resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.1.28.tgz",
+			"integrity": "sha512-yo1A32zMSaFv+hG9XcSkquA1GD8ph+Hx6hxOp8XQjtzkXA+TJzA0ehvDp1YCL6owBXn9RXphUC6mofPdDEFJKQ==",
+			"dev": true,
+			"requires": {
+				"@firebase/app": "0.7.27",
+				"@firebase/component": "0.5.16",
+				"@firebase/logger": "0.3.3",
+				"@firebase/util": "1.6.2",
+				"tslib": "^2.1.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 					"dev": true
 				}
 			}
@@ -220,171 +273,136 @@
 			"integrity": "sha512-L/ZnJRAq7F++utfuoTKX4CLBG5YR7tFO3PLzG1/oXXKEezJ0kRL3CMRoueBEmTCzVb/6SIs2Qlaw++uDgi5Xyg=="
 		},
 		"@firebase/auth": {
-			"version": "0.0.900-exp.894b5da5a",
-			"resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.0.900-exp.894b5da5a.tgz",
-			"integrity": "sha512-1z6+8GDqABujKRXeRBC4HdaTS/kn2A2k4wFxGn0YgaUJAnm3Znz4KSTqvg2mT82/GNnwBXhWgbjlmLt0vaVrvA==",
+			"version": "0.20.4",
+			"resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.20.4.tgz",
+			"integrity": "sha512-pWIrPB635QpPPbr7GFt2JMvSu/+Mgz/wLnMMrX3hHaPl4UlRLKdycohPSIZF+EGgc7PLx6p9fJvcw1fGEFZNXQ==",
 			"dev": true,
 			"requires": {
-				"@firebase/component": "0.4.1",
-				"@firebase/logger": "0.2.6",
-				"@firebase/util": "1.0.0",
-				"node-fetch": "2.6.1",
-				"selenium-webdriver": "4.0.0-beta.1",
+				"@firebase/component": "0.5.16",
+				"@firebase/logger": "0.3.3",
+				"@firebase/util": "1.6.2",
+				"node-fetch": "2.6.7",
+				"selenium-webdriver": "4.1.2",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 					"dev": true
 				}
 			}
 		},
 		"@firebase/auth-compat": {
-			"version": "0.0.900-exp.894b5da5a",
-			"resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.0.900-exp.894b5da5a.tgz",
-			"integrity": "sha512-g56ZU8pn7pY0IYHSvET8My9Q7wp//2bgTLdU9IuHxvmUy7v8pdpAKnpPkBu/tlAMK5MoV5vsxB21JuQBXuRp8A==",
+			"version": "0.2.17",
+			"resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.2.17.tgz",
+			"integrity": "sha512-GlEnDjziTEbFKqdILugBis9ZaQx57Y7bz5Uk41c793BusGXOgcZdrqjjM3DpNKPWBvi58rNbP0FdcAZA7DsWTw==",
 			"dev": true,
 			"requires": {
-				"@firebase/auth": "0.0.900-exp.894b5da5a",
-				"@firebase/auth-types": "0.10.2",
-				"@firebase/component": "0.4.1",
-				"@firebase/util": "1.0.0",
-				"node-fetch": "2.6.1",
-				"selenium-webdriver": "^4.0.0-beta.2",
+				"@firebase/auth": "0.20.4",
+				"@firebase/auth-types": "0.11.0",
+				"@firebase/component": "0.5.16",
+				"@firebase/util": "1.6.2",
+				"node-fetch": "2.6.7",
+				"selenium-webdriver": "4.1.2",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
-				"selenium-webdriver": {
-					"version": "4.0.0-beta.3",
-					"resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.0.0-beta.3.tgz",
-					"integrity": "sha512-R0mGHpQkSKgIWiPgcKDcckh4A6aaK0KTyWxs5ieuiI7zsXQ+Kb6neph+dNoeqq3jSBGyv3ONo2w3oohoL4D/Rg==",
-					"dev": true,
-					"requires": {
-						"jszip": "^3.5.0",
-						"rimraf": "^2.7.1",
-						"tmp": "^0.2.1",
-						"ws": "^7.3.1"
-					}
-				},
 				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
-					"dev": true
-				},
-				"ws": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.4.tgz",
-					"integrity": "sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw==",
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 					"dev": true
 				}
 			}
 		},
 		"@firebase/auth-interop-types": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.1.5.tgz",
-			"integrity": "sha512-88h74TMQ6wXChPA6h9Q3E1Jg6TkTHep2+k63OWg3s0ozyGVMeY+TTOti7PFPzq5RhszQPQOoCi59es4MaRvgCw==",
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.1.6.tgz",
+			"integrity": "sha512-etIi92fW3CctsmR9e3sYM3Uqnoq861M0Id9mdOPF6PWIg38BXL5k4upCNBggGUpLIS0H1grMOvy/wn1xymwe2g==",
 			"dev": true
 		},
 		"@firebase/auth-types": {
-			"version": "0.10.2",
-			"resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.10.2.tgz",
-			"integrity": "sha512-0GMWVWh5TBCYIQfVerxzDsuvhoFpK0++O9LtP3FWkwYo7EAxp6w0cftAg/8ntU1E5Wg56Ry0b6ti/YGP6g0jlg==",
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.11.0.tgz",
+			"integrity": "sha512-q7Bt6cx+ySj9elQHTsKulwk3+qDezhzRBFC9zlQ1BjgMueUOnGMcvqmU0zuKlQ4RhLSH7MNAdBV2znVaoN3Vxw==",
 			"dev": true
 		},
 		"@firebase/component": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.4.1.tgz",
-			"integrity": "sha512-f0IbIsoe33QzOj554rmDL04PyeZX/nNZYOAwlTzKmHq/JoFN6YoySi+0ZLyCtFrnRgw6zNnR/POXKOdfljWqZA==",
+			"version": "0.5.16",
+			"resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.16.tgz",
+			"integrity": "sha512-/pkl77mN9PT7dTSzNu1CrvIvd+z1CdePnEl+VITaeSBs9Ko7ZVvSIlzQLbSwqksXX3bAHpxej0Mg6mVKQiRVSw==",
 			"dev": true,
 			"requires": {
-				"@firebase/util": "1.0.0",
+				"@firebase/util": "1.6.2",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 					"dev": true
 				}
 			}
 		},
 		"@firebase/database": {
-			"version": "0.0.900-exp.894b5da5a",
-			"resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.0.900-exp.894b5da5a.tgz",
-			"integrity": "sha512-TAH6fn/9PwfeZS8ju0h14QzK8GbXGxrcup8qSeymTyS3Tklzo7hEWvlricnsx0f0oYwtXbW3WZEnfc2BaQLgOg==",
+			"version": "0.13.2",
+			"resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.13.2.tgz",
+			"integrity": "sha512-wKkBD4rq6PPv9gl1hNJNpl0R0bwJmXCJfDuvotjXmTcU7kV0AIaJ45GVhULkbSCApAAFC6QUJ91oasDUO1ZVxw==",
 			"dev": true,
 			"requires": {
-				"@firebase/auth-interop-types": "0.1.5",
-				"@firebase/component": "0.4.1",
-				"@firebase/database-types": "0.7.2",
-				"@firebase/logger": "0.2.6",
-				"@firebase/util": "1.0.0",
-				"faye-websocket": "0.11.3",
+				"@firebase/auth-interop-types": "0.1.6",
+				"@firebase/component": "0.5.16",
+				"@firebase/logger": "0.3.3",
+				"@firebase/util": "1.6.2",
+				"faye-websocket": "0.11.4",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
-				"@firebase/app-types": {
-					"version": "0.6.2",
-					"resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.6.2.tgz",
-					"integrity": "sha512-2VXvq/K+n8XMdM4L2xy5bYp2ZXMawJXluUIDzUBvMthVR+lhxK4pfFiqr1mmDbv9ydXvEAuFsD+6DpcZuJcSSw==",
-					"dev": true
-				},
-				"@firebase/database-types": {
-					"version": "0.7.2",
-					"resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.7.2.tgz",
-					"integrity": "sha512-cdAd/dgwvC0r3oLEDUR+ULs1vBsEvy0b27nlzKhU6LQgm9fCDzgaH9nFGv8x+S9dly4B0egAXkONkVoWcOAisg==",
-					"dev": true,
-					"requires": {
-						"@firebase/app-types": "0.6.2"
-					}
-				},
 				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 					"dev": true
 				}
 			}
 		},
 		"@firebase/database-compat": {
-			"version": "0.0.900-exp.894b5da5a",
-			"resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-0.0.900-exp.894b5da5a.tgz",
-			"integrity": "sha512-j/RYAsQISl2/m3QiSiWD8aa+8ryhjhu1km/Ts/dVf36owUix0XQ6gvL4PD23JO/WuRqEXpjeULK4S175aJBn/A==",
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-0.2.2.tgz",
+			"integrity": "sha512-3wLHJ54WHMhrveCywCMbkspshFezN07PLOIsmqELM1+pmrg3bwMj9u/o3Equ0DwmESMnchp5sMxgzdBUOextJg==",
 			"dev": true,
 			"requires": {
-				"@firebase/auth-interop-types": "0.1.5",
-				"@firebase/component": "0.4.1",
-				"@firebase/database": "0.0.900-exp.894b5da5a",
-				"@firebase/database-types": "0.7.2",
-				"@firebase/logger": "0.2.6",
-				"@firebase/util": "1.0.0",
-				"faye-websocket": "0.11.3",
+				"@firebase/component": "0.5.16",
+				"@firebase/database": "0.13.2",
+				"@firebase/database-types": "0.9.10",
+				"@firebase/logger": "0.3.3",
+				"@firebase/util": "1.6.2",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
 				"@firebase/app-types": {
-					"version": "0.6.2",
-					"resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.6.2.tgz",
-					"integrity": "sha512-2VXvq/K+n8XMdM4L2xy5bYp2ZXMawJXluUIDzUBvMthVR+lhxK4pfFiqr1mmDbv9ydXvEAuFsD+6DpcZuJcSSw==",
+					"version": "0.7.0",
+					"resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.7.0.tgz",
+					"integrity": "sha512-6fbHQwDv2jp/v6bXhBw2eSRbNBpxHcd1NBF864UksSMVIqIyri9qpJB1Mn6sGZE+bnDsSQBC5j2TbMxYsJQkQg==",
 					"dev": true
 				},
 				"@firebase/database-types": {
-					"version": "0.7.2",
-					"resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.7.2.tgz",
-					"integrity": "sha512-cdAd/dgwvC0r3oLEDUR+ULs1vBsEvy0b27nlzKhU6LQgm9fCDzgaH9nFGv8x+S9dly4B0egAXkONkVoWcOAisg==",
+					"version": "0.9.10",
+					"resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.9.10.tgz",
+					"integrity": "sha512-2ji6nXRRsY+7hgU6zRhUtK0RmSjVWM71taI7Flgaw+BnopCo/lDF5HSwxp8z7LtiHlvQqeRA3Ozqx5VhlAbiKg==",
 					"dev": true,
 					"requires": {
-						"@firebase/app-types": "0.6.2"
+						"@firebase/app-types": "0.7.0",
+						"@firebase/util": "1.6.2"
 					}
 				},
 				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 					"dev": true
 				}
 			}
@@ -398,386 +416,405 @@
 			}
 		},
 		"@firebase/firestore": {
-			"version": "0.0.900-exp.894b5da5a",
-			"resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-0.0.900-exp.894b5da5a.tgz",
-			"integrity": "sha512-aMCoGe1rN5ChmGgBU3GCqDWTG8GtbGrHq8wRmQGUrh90TDG4DX1ImF5xyJrymwST1juMk8kVtV1okvQ1zmPf8A==",
+			"version": "3.4.11",
+			"resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-3.4.11.tgz",
+			"integrity": "sha512-ZobzP2fQNiqT9Fh5x/8CmQVsWr3JJaM4l0xGHyaPc7vneRRC0Y0KcuKg3z3jBUXItXvlsIj7mGM4FucrxwhPzQ==",
 			"dev": true,
 			"requires": {
-				"@firebase/component": "0.4.1",
-				"@firebase/firestore-types": "2.2.0",
-				"@firebase/logger": "0.2.6",
-				"@firebase/util": "1.0.0",
-				"@firebase/webchannel-wrapper": "0.4.1",
-				"@grpc/grpc-js": "^1.0.0",
-				"@grpc/proto-loader": "^0.5.0",
-				"node-fetch": "2.6.1",
+				"@firebase/component": "0.5.16",
+				"@firebase/logger": "0.3.3",
+				"@firebase/util": "1.6.2",
+				"@firebase/webchannel-wrapper": "0.6.2",
+				"@grpc/grpc-js": "^1.3.2",
+				"@grpc/proto-loader": "^0.6.0",
+				"node-fetch": "2.6.7",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 					"dev": true
 				}
 			}
 		},
 		"@firebase/firestore-compat": {
-			"version": "0.0.900-exp.894b5da5a",
-			"resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.0.900-exp.894b5da5a.tgz",
-			"integrity": "sha512-CjT+5wp3jyJwUWI8hKhlg7WxpbLToHbBm9BF9BpihDY1j0IyJmBICC0LJEtXsib/IOPIsf04rxUiFHKX4ciOHg==",
+			"version": "0.1.20",
+			"resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.1.20.tgz",
+			"integrity": "sha512-0+WAh+pjCi0t/DK5cefECiwQGiZbrAU2UenZ61Uly1w7L5ob932Qc61OQKk+Y2VD+IQ7YPcBpUM7X6JOSbgJ6g==",
 			"dev": true,
 			"requires": {
-				"@firebase/component": "0.4.1",
-				"@firebase/firestore": "0.0.900-exp.894b5da5a",
-				"@firebase/firestore-types": "2.2.0",
-				"@firebase/logger": "0.2.6",
-				"@firebase/util": "1.0.0",
-				"@firebase/webchannel-wrapper": "0.4.1",
-				"@grpc/grpc-js": "^1.0.0",
-				"@grpc/proto-loader": "^0.5.0",
-				"node-fetch": "2.6.1",
+				"@firebase/component": "0.5.16",
+				"@firebase/firestore": "3.4.11",
+				"@firebase/firestore-types": "2.5.0",
+				"@firebase/util": "1.6.2",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 					"dev": true
 				}
 			}
 		},
 		"@firebase/firestore-types": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-2.2.0.tgz",
-			"integrity": "sha512-5kZZtQ32FIRJP1029dw+ZVNRCclKOErHv1+Xn0pw/5Fq3dxroA/ZyFHqDu+uV52AyWHhNLjCqX43ibm4YqOzRw==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-2.5.0.tgz",
+			"integrity": "sha512-I6c2m1zUhZ5SH0cWPmINabDyH5w0PPFHk2UHsjBpKdZllzJZ2TwTkXbDtpHUZNmnc/zAa0WNMNMvcvbb/xJLKA==",
 			"dev": true
 		},
 		"@firebase/functions": {
-			"version": "0.0.900-exp.894b5da5a",
-			"resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.0.900-exp.894b5da5a.tgz",
-			"integrity": "sha512-7094mgWbVsMLaeKalQkEVvaydS+l1f/gytFXYyz+qtazYvghsrQd+n5pJQBzbBVNHw2NAQrJxHrePCftw8u2jg==",
+			"version": "0.8.3",
+			"resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.8.3.tgz",
+			"integrity": "sha512-0mc59I97S61fvDiVhqj/k5GwSDM/mSWe+xgyxT1UWD3vocvZ5JOx0bhPwbpa7lStI6DWCiWhZrEQlp16Y7i1yg==",
 			"dev": true,
 			"requires": {
-				"@firebase/component": "0.4.1",
-				"@firebase/messaging-types": "0.5.0",
-				"@firebase/util": "1.0.0",
-				"node-fetch": "2.6.1",
+				"@firebase/app-check-interop-types": "0.1.0",
+				"@firebase/auth-interop-types": "0.1.6",
+				"@firebase/component": "0.5.16",
+				"@firebase/messaging-interop-types": "0.1.0",
+				"@firebase/util": "1.6.2",
+				"node-fetch": "2.6.7",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 					"dev": true
 				}
 			}
 		},
 		"@firebase/functions-compat": {
-			"version": "0.0.900-exp.894b5da5a",
-			"resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.0.900-exp.894b5da5a.tgz",
-			"integrity": "sha512-M57QEQ8TN12lYEMJZ3anaRGILJ59nOU4Xp6cCHsAbB5DkYLuxoHccvfZCzwmv95hEhF1mSvFPrZRJG9F3PVmZg==",
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.2.3.tgz",
+			"integrity": "sha512-we6a5a6HcCwLMXzITNWfvBxxIlCqcXCeUsomEb0Gyf1/ecVod8L3dcsWNTZB87OYjTSpVS+Jn+H+NpjOMvrlmA==",
 			"dev": true,
 			"requires": {
-				"@firebase/component": "0.4.1",
-				"@firebase/functions": "0.0.900-exp.894b5da5a",
-				"@firebase/functions-types": "0.4.0",
-				"@firebase/messaging-types": "0.5.0",
-				"@firebase/util": "1.0.0",
+				"@firebase/component": "0.5.16",
+				"@firebase/functions": "0.8.3",
+				"@firebase/functions-types": "0.5.0",
+				"@firebase/util": "1.6.2",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 					"dev": true
 				}
 			}
 		},
 		"@firebase/functions-types": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.4.0.tgz",
-			"integrity": "sha512-3KElyO3887HNxtxNF1ytGFrNmqD+hheqjwmT3sI09FaDCuaxGbOnsXAXH2eQ049XRXw9YQpHMgYws/aUNgXVyQ==",
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.5.0.tgz",
+			"integrity": "sha512-qza0M5EwX+Ocrl1cYI14zoipUX4gI/Shwqv0C1nB864INAD42Dgv4v94BCyxGHBg2kzlWy8PNafdP7zPO8aJQA==",
 			"dev": true
 		},
 		"@firebase/installations": {
-			"version": "0.0.900-exp.894b5da5a",
-			"resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.0.900-exp.894b5da5a.tgz",
-			"integrity": "sha512-mKjQq3etoZdZVCfUap+2tJgqS6AFHptg5HUBmUVGn+5Nz74i4n8M/M4W/qhXIjlnEcdLGop+5XaE9Tm03tbC7Q==",
+			"version": "0.5.11",
+			"resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.5.11.tgz",
+			"integrity": "sha512-54pTWQXYHBNlwUwtHDitr/N4dFOBi/LYoBlpbyIrjlqdkXSk0WOVDMV15cMdfCyCZQgJVMW78c52ZrDZxwW05g==",
 			"dev": true,
 			"requires": {
-				"@firebase/component": "0.4.1",
-				"@firebase/util": "1.0.0",
-				"idb": "3.0.2",
+				"@firebase/component": "0.5.16",
+				"@firebase/util": "1.6.2",
+				"idb": "7.0.1",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 					"dev": true
 				}
 			}
 		},
 		"@firebase/logger": {
-			"version": "0.2.6",
-			"resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.2.6.tgz",
-			"integrity": "sha512-KIxcUvW/cRGWlzK9Vd2KB864HlUnCfdTH0taHE0sXW5Xl7+W68suaeau1oKNEqmc3l45azkd4NzXTCWZRZdXrw==",
-			"dev": true
-		},
-		"@firebase/messaging": {
-			"version": "0.0.900-exp.894b5da5a",
-			"resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.0.900-exp.894b5da5a.tgz",
-			"integrity": "sha512-Bvg5Fr0i9tkwYT+mANggr8IzGH+IoPR7u11ZWOp4Iwo3gVgH2Q2kaDHBxxaV07k33Vqs4xCGq+f5sc56yI9GUQ==",
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.3.3.tgz",
+			"integrity": "sha512-POTJl07jOKTOevLXrTvJD/VZ0M6PnJXflbAh5J9VGkmtXPXNG6MdZ9fmRgqYhXKTaDId6AQenQ262uwgpdtO0Q==",
 			"dev": true,
 			"requires": {
-				"@firebase/component": "0.4.1",
-				"@firebase/installations": "0.0.900-exp.894b5da5a",
-				"@firebase/util": "1.0.0",
-				"idb": "3.0.2",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+					"dev": true
+				}
+			}
+		},
+		"@firebase/messaging": {
+			"version": "0.9.15",
+			"resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.9.15.tgz",
+			"integrity": "sha512-UEMbjj3UdsHipdljrFMNyasYLPzEOLXRfaZdpV7StHuqa5r3M9jKRM16tcszNMWXVNuiXT4k0VPXXGZPtiYQDQ==",
+			"dev": true,
+			"requires": {
+				"@firebase/component": "0.5.16",
+				"@firebase/installations": "0.5.11",
+				"@firebase/messaging-interop-types": "0.1.0",
+				"@firebase/util": "1.6.2",
+				"idb": "7.0.1",
+				"tslib": "^2.1.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 					"dev": true
 				}
 			}
 		},
 		"@firebase/messaging-compat": {
-			"version": "0.0.900-exp.894b5da5a",
-			"resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.0.900-exp.894b5da5a.tgz",
-			"integrity": "sha512-LkkaK7KFj4xQhJS/ihFlHZfofgSYPWtHuCKv+vC8ANhl0BB4GMPU5huQ9sHLlQQxnmRViemXdphKNDceEnOzhQ==",
+			"version": "0.1.15",
+			"resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.1.15.tgz",
+			"integrity": "sha512-f9xbp/V4onNgg7tTC9rY/9gb5F3S+1m1YMU39GHATXcoO4qVCN429VFbVSWQ9RI7f85HddPsULWX7Moq+MwzNw==",
 			"dev": true,
 			"requires": {
-				"@firebase/component": "0.4.1",
-				"@firebase/installations": "0.0.900-exp.894b5da5a",
-				"@firebase/messaging": "0.0.900-exp.894b5da5a",
-				"@firebase/util": "1.0.0",
+				"@firebase/component": "0.5.16",
+				"@firebase/messaging": "0.9.15",
+				"@firebase/util": "1.6.2",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 					"dev": true
 				}
 			}
 		},
-		"@firebase/messaging-types": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/@firebase/messaging-types/-/messaging-types-0.5.0.tgz",
-			"integrity": "sha512-QaaBswrU6umJYb/ZYvjR5JDSslCGOH6D9P136PhabFAHLTR4TWjsaACvbBXuvwrfCXu10DtcjMxqfhdNIB1Xfg==",
+		"@firebase/messaging-interop-types": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.1.0.tgz",
+			"integrity": "sha512-DbvUl/rXAZpQeKBnwz0NYY5OCqr2nFA0Bj28Fmr3NXGqR4PAkfTOHuQlVtLO1Nudo3q0HxAYLa68ZDAcuv2uKQ==",
 			"dev": true
 		},
 		"@firebase/performance": {
-			"version": "0.0.900-exp.894b5da5a",
-			"resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.0.900-exp.894b5da5a.tgz",
-			"integrity": "sha512-AObB2165d+DDuCN1p0wzJisA6CPqnDeZKnFOcOuMsVnQjRCC1smIDomXoDcNCh+9nEkz6MrGPZnhGgN5OGzT1Q==",
+			"version": "0.5.11",
+			"resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.5.11.tgz",
+			"integrity": "sha512-neHlHi1bs0LkNCZgzSWBm+YBqkaKFkxj+JtD4E4EQTENdHsAAAL4JnSKPOP1c+4CQqDnRbYW9QMXPcDlL21pow==",
 			"dev": true,
 			"requires": {
-				"@firebase/component": "0.4.1",
-				"@firebase/installations": "0.0.900-exp.894b5da5a",
-				"@firebase/logger": "0.2.6",
-				"@firebase/util": "1.0.0",
+				"@firebase/component": "0.5.16",
+				"@firebase/installations": "0.5.11",
+				"@firebase/logger": "0.3.3",
+				"@firebase/util": "1.6.2",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 					"dev": true
 				}
 			}
 		},
 		"@firebase/performance-compat": {
-			"version": "0.0.900-exp.894b5da5a",
-			"resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.0.900-exp.894b5da5a.tgz",
-			"integrity": "sha512-x4MiVQNYin4h90IoGOYkgWFSwH40u3M0YOx+YlBp0l+cKO74s9Rm0DVVNjVz3DZPC3WI1QCT2ImYiszJhQgwTg==",
+			"version": "0.1.11",
+			"resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.1.11.tgz",
+			"integrity": "sha512-M1paA6KG4j5OGvgpvg25Y6x5/lUIpSJVL6fyq4af3YjFcLoSijqiBq/KTiFEt3vLJWiOmK2p9Apu3MHiffBi0A==",
 			"dev": true,
 			"requires": {
-				"@firebase/component": "0.4.1",
-				"@firebase/logger": "0.2.6",
-				"@firebase/performance": "0.0.900-exp.894b5da5a",
-				"@firebase/performance-types": "0.0.13",
-				"@firebase/util": "1.0.0",
+				"@firebase/component": "0.5.16",
+				"@firebase/logger": "0.3.3",
+				"@firebase/performance": "0.5.11",
+				"@firebase/performance-types": "0.1.0",
+				"@firebase/util": "1.6.2",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 					"dev": true
 				}
 			}
 		},
 		"@firebase/performance-types": {
-			"version": "0.0.13",
-			"resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.0.13.tgz",
-			"integrity": "sha512-6fZfIGjQpwo9S5OzMpPyqgYAUZcFzZxHFqOyNtorDIgNXq33nlldTL/vtaUZA8iT9TT5cJlCrF/jthKU7X21EA==",
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.1.0.tgz",
+			"integrity": "sha512-6p1HxrH0mpx+622Ql6fcxFxfkYSBpE3LSuwM7iTtYU2nw91Hj6THC8Bc8z4nboIq7WvgsT/kOTYVVZzCSlXl8w==",
 			"dev": true
 		},
-		"@firebase/remote-config": {
-			"version": "0.0.900-exp.894b5da5a",
-			"resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.0.900-exp.894b5da5a.tgz",
-			"integrity": "sha512-+5rO3r8zLDufpt1VO6Urm4/YluAYkvITpwzGPA+vv7a+Bs5P+Et4Z1bleUjSdlqJAZMpGnx748+AZYXiVxBtgQ==",
+		"@firebase/polyfill": {
+			"version": "0.3.36",
+			"resolved": "https://registry.npmjs.org/@firebase/polyfill/-/polyfill-0.3.36.tgz",
+			"integrity": "sha512-zMM9oSJgY6cT2jx3Ce9LYqb0eIpDE52meIzd/oe/y70F+v9u1LDqk5kUF5mf16zovGBWMNFmgzlsh6Wj0OsFtg==",
 			"dev": true,
 			"requires": {
-				"@firebase/component": "0.4.1",
-				"@firebase/installations": "0.0.900-exp.894b5da5a",
-				"@firebase/logger": "0.2.6",
-				"@firebase/util": "1.0.0",
+				"core-js": "3.6.5",
+				"promise-polyfill": "8.1.3",
+				"whatwg-fetch": "2.0.4"
+			}
+		},
+		"@firebase/remote-config": {
+			"version": "0.3.10",
+			"resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.3.10.tgz",
+			"integrity": "sha512-n55NDxX9kt6QoDH0z3Ryjbjx/S6xNobfjK/hdMN/3fNZh0WSuAZKMWUiw/59cnbZkFxQBncOGDN5Cc/bdp3bdg==",
+			"dev": true,
+			"requires": {
+				"@firebase/component": "0.5.16",
+				"@firebase/installations": "0.5.11",
+				"@firebase/logger": "0.3.3",
+				"@firebase/util": "1.6.2",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 					"dev": true
 				}
 			}
 		},
 		"@firebase/remote-config-compat": {
-			"version": "0.0.900-exp.894b5da5a",
-			"resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.0.900-exp.894b5da5a.tgz",
-			"integrity": "sha512-o78QgpipoRG/XiuzIGGgVX1PZS6xF4FPaQXbANtE+qdNJUpVfBVk6WpzeDlRE4c1h/EAJJi3fL4RZRmyy/b/WQ==",
+			"version": "0.1.11",
+			"resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.1.11.tgz",
+			"integrity": "sha512-75mjt2M+MXa/j2J9wuRVrUFDekFoKkK5/ogBPxckvjzSXGDDwbGmrrb0MwG6BdUSxSUaHrAeUYhEQ2vwNfa1Gw==",
 			"dev": true,
 			"requires": {
-				"@firebase/component": "0.4.1",
-				"@firebase/logger": "0.2.6",
-				"@firebase/remote-config": "0.0.900-exp.894b5da5a",
-				"@firebase/remote-config-types": "0.1.9",
-				"@firebase/util": "1.0.0",
+				"@firebase/component": "0.5.16",
+				"@firebase/logger": "0.3.3",
+				"@firebase/remote-config": "0.3.10",
+				"@firebase/remote-config-types": "0.2.0",
+				"@firebase/util": "1.6.2",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 					"dev": true
 				}
 			}
 		},
 		"@firebase/remote-config-types": {
-			"version": "0.1.9",
-			"resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.1.9.tgz",
-			"integrity": "sha512-G96qnF3RYGbZsTRut7NBX0sxyczxt1uyCgXQuH/eAfUCngxjEGcZQnBdy6mvSdqdJh5mC31rWPO4v9/s7HwtzA==",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.2.0.tgz",
+			"integrity": "sha512-hqK5sCPeZvcHQ1D6VjJZdW6EexLTXNMJfPdTwbD8NrXUw6UjWC4KWhLK/TSlL0QPsQtcKRkaaoP+9QCgKfMFPw==",
 			"dev": true
 		},
 		"@firebase/storage": {
-			"version": "0.0.900-exp.894b5da5a",
-			"resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.0.900-exp.894b5da5a.tgz",
-			"integrity": "sha512-ECz2F9m3rUMutsnlx5Uv3mTQgXva5Q4PFNjkrE8c5d8VHfyl6dPxjBIbqK0Qi+QiFUfnWj7zyVyn5f9ADpIa8Q==",
+			"version": "0.9.8",
+			"resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.9.8.tgz",
+			"integrity": "sha512-tfRDVjDjTDIBHm7CTFcboZ7UC+GUKkBIhmoHt2tTVyZfEDKtE4ZPnHy7i6RSeY624wM+/IGWn5o+1CCf3uEEGQ==",
 			"dev": true,
 			"requires": {
-				"@firebase/component": "0.4.1",
-				"@firebase/storage-types": "0.4.0",
-				"@firebase/util": "1.0.0",
+				"@firebase/component": "0.5.16",
+				"@firebase/util": "1.6.2",
+				"node-fetch": "2.6.7",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 					"dev": true
 				}
 			}
 		},
 		"@firebase/storage-compat": {
-			"version": "0.0.900-exp.894b5da5a",
-			"resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.0.900-exp.894b5da5a.tgz",
-			"integrity": "sha512-cmMZzwxv0eTEjanXjt6tjGTAQ+MaZpmNtC0c5vG9ZZI53kCnyCtljfnAtIaCYdJvc4BMsXEsdm0shYQ7R8JTQw==",
+			"version": "0.1.16",
+			"resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.1.16.tgz",
+			"integrity": "sha512-YSK0QHPCyyALBiJHvtlejrmtrQKst7aJiHyEm1VkcyLdm5RMcZ6JkdObOeACxa9/qwATYQLNlwy/C+//RuzyrA==",
 			"dev": true,
 			"requires": {
-				"@firebase/component": "0.4.1",
-				"@firebase/storage": "0.0.900-exp.894b5da5a",
-				"@firebase/storage-types": "0.4.0",
-				"@firebase/util": "1.0.0",
+				"@firebase/component": "0.5.16",
+				"@firebase/storage": "0.9.8",
+				"@firebase/storage-types": "0.6.0",
+				"@firebase/util": "1.6.2",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 					"dev": true
 				}
 			}
 		},
 		"@firebase/storage-types": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.4.0.tgz",
-			"integrity": "sha512-2xgiLGfDv6Fz5qRrsO47/7PfbV9P+5tEuvEktJYTNxrgTxGPj3sMb7ZkycIb4JE98fAbmGEeMQaRSorqR5bEIQ==",
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.6.0.tgz",
+			"integrity": "sha512-1LpWhcCb1ftpkP/akhzjzeFxgVefs6eMD2QeKiJJUGH1qOiows2w5o0sKCUSQrvrRQS1lz3SFGvNR1Ck/gqxeA==",
 			"dev": true
 		},
 		"@firebase/util": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.0.0.tgz",
-			"integrity": "sha512-KIEyuyrYKKtit+lAl66c2GVvooM1Pb+Yw/9yuSga1HKYMxNZwSsIMXU8X97sLZf7WJaanV1XNJEMkZTw3xKEoA==",
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.6.2.tgz",
+			"integrity": "sha512-VYDqEf/+mS7n0nPj6qJDJYFtKIEfOaTtQeNDsd3x+xp8HWvrbygWOexzeGicLP1dvEzrKr3eQGcJmmmYN3TIsA==",
 			"dev": true,
 			"requires": {
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 					"dev": true
 				}
 			}
 		},
 		"@firebase/webchannel-wrapper": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.4.1.tgz",
-			"integrity": "sha512-0yPjzuzGMkW1GkrC8yWsiN7vt1OzkMIi9HgxRmKREZl2wnNPOKo/yScTjXf/O57HM8dltqxPF6jlNLFVtc2qdw==",
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.6.2.tgz",
+			"integrity": "sha512-zThUKcqIU6utWzM93uEvhlh8qj8A5LMPFJPvk/ODb+8GSSif19xM2Lw1M2ijyBy8+6skSkQBbavPzOU5Oh/8tQ==",
 			"dev": true
 		},
 		"@grpc/grpc-js": {
-			"version": "1.2.12",
-			"resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.2.12.tgz",
-			"integrity": "sha512-+gPCklP1eqIgrNPyzddYQdt9+GvZqPlLpIjIo+TveE+gbtp74VV1A2ju8ExeO8ma8f7MbpaGZx/KJPYVWL9eDw==",
+			"version": "1.6.7",
+			"resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.6.7.tgz",
+			"integrity": "sha512-eBM03pu9hd3VqDQG+kHahiG1x80RGkkqqRb1Pchcwqej/KkAH95gAvKs6laqaHCycYaPK+TKuNQnOz9UXYA8qw==",
 			"dev": true,
 			"requires": {
-				"@types/node": ">=12.12.47",
-				"google-auth-library": "^6.1.1",
-				"semver": "^6.2.0"
+				"@grpc/proto-loader": "^0.6.4",
+				"@types/node": ">=12.12.47"
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "14.14.37",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.37.tgz",
-					"integrity": "sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==",
+					"version": "18.0.0",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
+					"integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==",
 					"dev": true
 				}
 			}
 		},
 		"@grpc/proto-loader": {
-			"version": "0.5.6",
-			"resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.5.6.tgz",
-			"integrity": "sha512-DT14xgw3PSzPxwS13auTEwxhMMOoz33DPUKNtmYK/QYbBSpLXJy78FGGs5yVoxVobEqPm4iW9MOIoz0A3bLTRQ==",
+			"version": "0.6.13",
+			"resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.13.tgz",
+			"integrity": "sha512-FjxPYDRTn6Ec3V0arm1FtSpmP6V50wuph2yILpyvTKzjc76oDdoihXqM1DzOW5ubvCC8GivfCnNtfaRE8myJ7g==",
 			"dev": true,
 			"requires": {
+				"@types/long": "^4.0.1",
 				"lodash.camelcase": "^4.3.0",
-				"protobufjs": "^6.8.6"
+				"long": "^4.0.0",
+				"protobufjs": "^6.11.3",
+				"yargs": "^16.2.0"
 			}
 		},
 		"@protobufjs/aspromise": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-			"integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78=",
+			"integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
 			"dev": true
 		},
 		"@protobufjs/base64": {
@@ -795,13 +832,13 @@
 		"@protobufjs/eventemitter": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-			"integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A=",
+			"integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
 			"dev": true
 		},
 		"@protobufjs/fetch": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-			"integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+			"integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
 			"dev": true,
 			"requires": {
 				"@protobufjs/aspromise": "^1.1.1",
@@ -811,31 +848,31 @@
 		"@protobufjs/float": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-			"integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=",
+			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
 			"dev": true
 		},
 		"@protobufjs/inquire": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-			"integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=",
+			"integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
 			"dev": true
 		},
 		"@protobufjs/path": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-			"integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=",
+			"integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
 			"dev": true
 		},
 		"@protobufjs/pool": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-			"integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=",
+			"integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
 			"dev": true
 		},
 		"@protobufjs/utf8": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-			"integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=",
+			"integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
 			"dev": true
 		},
 		"@types/chai": {
@@ -851,9 +888,9 @@
 			"dev": true
 		},
 		"@types/long": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
-			"integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+			"integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
 			"dev": true
 		},
 		"@types/mocha": {
@@ -883,15 +920,6 @@
 			"integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
 			"dev": true
 		},
-		"abort-controller": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-			"integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-			"dev": true,
-			"requires": {
-				"event-target-shim": "^5.0.0"
-			}
-		},
 		"acorn": {
 			"version": "6.4.2",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
@@ -914,15 +942,6 @@
 			"integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
 			"dev": true
 		},
-		"agent-base": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-			"dev": true,
-			"requires": {
-				"debug": "4"
-			}
-		},
 		"ajv": {
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -934,6 +953,12 @@
 				"json-schema-traverse": "^0.4.1",
 				"uri-js": "^4.2.2"
 			}
+		},
+		"ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true
 		},
 		"ansi-styles": {
 			"version": "3.2.1",
@@ -984,12 +1009,6 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
 			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-			"dev": true
-		},
-		"arrify": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-			"integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
 			"dev": true
 		},
 		"asn1": {
@@ -1043,12 +1062,6 @@
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 			"dev": true
 		},
-		"base64-js": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-			"dev": true
-		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -1057,12 +1070,6 @@
 			"requires": {
 				"tweetnacl": "^0.14.3"
 			}
-		},
-		"bignumber.js": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
-			"integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==",
-			"dev": true
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
@@ -1095,12 +1102,6 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
 			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-			"dev": true
-		},
-		"buffer-equal-constant-time": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-			"integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
 			"dev": true
 		},
 		"buffer-from": {
@@ -1152,6 +1153,17 @@
 			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
 			"dev": true
 		},
+		"cliui": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+			"dev": true,
+			"requires": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.0",
+				"wrap-ansi": "^7.0.0"
+			}
+		},
 		"color-convert": {
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -1186,6 +1198,12 @@
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
+		},
+		"core-js": {
+			"version": "3.6.5",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+			"integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
 			"dev": true
 		},
 		"core-util-is": {
@@ -1278,12 +1296,6 @@
 			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
 			"dev": true
 		},
-		"dom-storage": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/dom-storage/-/dom-storage-2.1.0.tgz",
-			"integrity": "sha512-g6RpyWXzl0RR6OTElHKBl7nwnK87GUyZMYC7JWsB/IA73vpqK2K6LT39x4VepLxlSsWBFrPVLnsSR5Jyty0+2Q==",
-			"dev": true
-		},
 		"domexception": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
@@ -1303,14 +1315,17 @@
 				"safer-buffer": "^2.1.0"
 			}
 		},
-		"ecdsa-sig-formatter": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-			"dev": true,
-			"requires": {
-				"safe-buffer": "^5.0.1"
-			}
+		"emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true
+		},
+		"escalade": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+			"dev": true
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
@@ -1353,12 +1368,6 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-			"dev": true
-		},
-		"event-target-shim": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
 			"dev": true
 		},
 		"expand-brackets": {
@@ -1418,16 +1427,10 @@
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
 			"dev": true
 		},
-		"fast-text-encoding": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz",
-			"integrity": "sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig==",
-			"dev": true
-		},
 		"faye-websocket": {
-			"version": "0.11.3",
-			"resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
-			"integrity": "sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==",
+			"version": "0.11.4",
+			"resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+			"integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
 			"dev": true,
 			"requires": {
 				"websocket-driver": ">=0.5.1"
@@ -1453,31 +1456,45 @@
 			}
 		},
 		"firebase": {
-			"version": "9.0.0-beta.1",
-			"resolved": "https://registry.npmjs.org/firebase/-/firebase-9.0.0-beta.1.tgz",
-			"integrity": "sha512-dYPrlGUi+JYqQIydE4LGZ7A2X5uFazwUNbAX0s7N1S34swvgp5Xz2ww63DB+hwjglF6eH+PiMGBDSZSG7hikUw==",
+			"version": "9.8.4",
+			"resolved": "https://registry.npmjs.org/firebase/-/firebase-9.8.4.tgz",
+			"integrity": "sha512-fQigVEtSBprGBDLVTr485KQJ1YUWh/HeocMQvmhaUCL9dHUnW8GWfK+XkKOV2kcDB1Ur8xZPkjCxlmoTcykhgA==",
 			"dev": true,
 			"requires": {
-				"@firebase/analytics": "0.0.900-exp.894b5da5a",
-				"@firebase/analytics-compat": "0.0.900-exp.894b5da5a",
-				"@firebase/app": "0.0.900-exp.894b5da5a",
-				"@firebase/app-compat": "0.0.900-exp.894b5da5a",
-				"@firebase/auth": "0.0.900-exp.894b5da5a",
-				"@firebase/auth-compat": "0.0.900-exp.894b5da5a",
-				"@firebase/database": "0.0.900-exp.894b5da5a",
-				"@firebase/database-compat": "0.0.900-exp.894b5da5a",
-				"@firebase/firestore": "0.0.900-exp.894b5da5a",
-				"@firebase/firestore-compat": "0.0.900-exp.894b5da5a",
-				"@firebase/functions": "0.0.900-exp.894b5da5a",
-				"@firebase/functions-compat": "0.0.900-exp.894b5da5a",
-				"@firebase/messaging": "0.0.900-exp.894b5da5a",
-				"@firebase/messaging-compat": "0.0.900-exp.894b5da5a",
-				"@firebase/performance": "0.0.900-exp.894b5da5a",
-				"@firebase/performance-compat": "0.0.900-exp.894b5da5a",
-				"@firebase/remote-config": "0.0.900-exp.894b5da5a",
-				"@firebase/remote-config-compat": "0.0.900-exp.894b5da5a",
-				"@firebase/storage": "0.0.900-exp.894b5da5a",
-				"@firebase/storage-compat": "0.0.900-exp.894b5da5a"
+				"@firebase/analytics": "0.7.11",
+				"@firebase/analytics-compat": "0.1.12",
+				"@firebase/app": "0.7.27",
+				"@firebase/app-check": "0.5.10",
+				"@firebase/app-check-compat": "0.2.10",
+				"@firebase/app-compat": "0.1.28",
+				"@firebase/app-types": "0.7.0",
+				"@firebase/auth": "0.20.4",
+				"@firebase/auth-compat": "0.2.17",
+				"@firebase/database": "0.13.2",
+				"@firebase/database-compat": "0.2.2",
+				"@firebase/firestore": "3.4.11",
+				"@firebase/firestore-compat": "0.1.20",
+				"@firebase/functions": "0.8.3",
+				"@firebase/functions-compat": "0.2.3",
+				"@firebase/installations": "0.5.11",
+				"@firebase/messaging": "0.9.15",
+				"@firebase/messaging-compat": "0.1.15",
+				"@firebase/performance": "0.5.11",
+				"@firebase/performance-compat": "0.1.11",
+				"@firebase/polyfill": "0.3.36",
+				"@firebase/remote-config": "0.3.10",
+				"@firebase/remote-config-compat": "0.1.11",
+				"@firebase/storage": "0.9.8",
+				"@firebase/storage-compat": "0.1.16",
+				"@firebase/util": "1.6.2"
+			},
+			"dependencies": {
+				"@firebase/app-types": {
+					"version": "0.7.0",
+					"resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.7.0.tgz",
+					"integrity": "sha512-6fbHQwDv2jp/v6bXhBw2eSRbNBpxHcd1NBF864UksSMVIqIyri9qpJB1Mn6sGZE+bnDsSQBC5j2TbMxYsJQkQg==",
+					"dev": true
+				}
 			}
 		},
 		"for-in": {
@@ -1535,28 +1552,11 @@
 			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
 			"dev": true
 		},
-		"gaxios": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.2.0.tgz",
-			"integrity": "sha512-Ms7fNifGv0XVU+6eIyL9LB7RVESeML9+cMvkwGS70xyD6w2Z80wl6RiqiJ9k1KFlJCUTQqFFc8tXmPQfSKUe8g==",
-			"dev": true,
-			"requires": {
-				"abort-controller": "^3.0.0",
-				"extend": "^3.0.2",
-				"https-proxy-agent": "^5.0.0",
-				"is-stream": "^2.0.0",
-				"node-fetch": "^2.3.0"
-			}
-		},
-		"gcp-metadata": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.2.1.tgz",
-			"integrity": "sha512-tSk+REe5iq/N+K+SK1XjZJUrFPuDqGZVzCy2vocIHIGmPlTGsa8owXMJwGkrXr73NO0AzhPW4MF2DEHz7P2AVw==",
-			"dev": true,
-			"requires": {
-				"gaxios": "^4.0.0",
-				"json-bigint": "^1.0.0"
-			}
+		"get-caller-file": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"dev": true
 		},
 		"get-func-name": {
 			"version": "2.0.0",
@@ -1612,32 +1612,6 @@
 			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
 			"dev": true
 		},
-		"google-auth-library": {
-			"version": "6.1.6",
-			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.6.tgz",
-			"integrity": "sha512-Q+ZjUEvLQj/lrVHF/IQwRo6p3s8Nc44Zk/DALsN+ac3T4HY/g/3rrufkgtl+nZ1TW7DNAw5cTChdVp4apUXVgQ==",
-			"dev": true,
-			"requires": {
-				"arrify": "^2.0.0",
-				"base64-js": "^1.3.0",
-				"ecdsa-sig-formatter": "^1.0.11",
-				"fast-text-encoding": "^1.0.0",
-				"gaxios": "^4.0.0",
-				"gcp-metadata": "^4.2.0",
-				"gtoken": "^5.0.4",
-				"jws": "^4.0.0",
-				"lru-cache": "^6.0.0"
-			}
-		},
-		"google-p12-pem": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.0.3.tgz",
-			"integrity": "sha512-wS0ek4ZtFx/ACKYF3JhyGe5kzH7pgiQ7J5otlumqR9psmWMYc+U9cErKlCYVYHoUaidXHdZ2xbo34kB+S+24hA==",
-			"dev": true,
-			"requires": {
-				"node-forge": "^0.10.0"
-			}
-		},
 		"graceful-fs": {
 			"version": "4.2.6",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
@@ -1649,17 +1623,6 @@
 			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
 			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
 			"dev": true
-		},
-		"gtoken": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.2.1.tgz",
-			"integrity": "sha512-OY0BfPKe3QnMsY9MzTHTSKn+Vl2l1CcLe6BwDEQj00mbbkl5nyQ/7EUREstg4fQNZ8iYE7br4JJ7TdKeDOPWmw==",
-			"dev": true,
-			"requires": {
-				"gaxios": "^4.0.0",
-				"google-p12-pem": "^3.0.3",
-				"jws": "^4.0.0"
-			}
 		},
 		"har-schema": {
 			"version": "2.0.0",
@@ -1708,9 +1671,9 @@
 			}
 		},
 		"http-parser-js": {
-			"version": "0.5.3",
-			"resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.3.tgz",
-			"integrity": "sha512-t7hjvef/5HEK7RWTdUzVUhl8zkEu+LlaE0IYzdMuvbSDipxBRpOn4Uhw8ZyECEa808iVT8XCjzo6xmYt4CiLZg==",
+			"version": "0.5.8",
+			"resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.8.tgz",
+			"integrity": "sha512-SGeBX54F94Wgu5RH3X5jsDtf4eHyRogWX1XGT3b4HuW3tQPM4AaBzoUji/4AAJNXCEOWZ5O0DgZmJw1947gD5Q==",
 			"dev": true
 		},
 		"http-signature": {
@@ -1724,16 +1687,6 @@
 				"sshpk": "^1.7.0"
 			}
 		},
-		"https-proxy-agent": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-			"integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-			"dev": true,
-			"requires": {
-				"agent-base": "6",
-				"debug": "4"
-			}
-		},
 		"iconv-lite": {
 			"version": "0.4.24",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -1744,15 +1697,15 @@
 			}
 		},
 		"idb": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/idb/-/idb-3.0.2.tgz",
-			"integrity": "sha512-+FLa/0sTXqyux0o6C+i2lOR0VoS60LU/jzUo5xjfY6+7sEEgy4Gz1O7yFBXvjd7N0NyIGWIRg8DcQSLEG+VSPw==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/idb/-/idb-7.0.1.tgz",
+			"integrity": "sha512-UUxlE7vGWK5RfB/fDwEGgRf84DY/ieqNha6msMV99UsEMQhJ1RwbCd8AYBj3QMgnE3VZnfQvm4oKVCJTYlqIgg==",
 			"dev": true
 		},
 		"immediate": {
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-			"integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
+			"integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
 			"dev": true
 		},
 		"inflight": {
@@ -1813,6 +1766,12 @@
 			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
 			"dev": true
 		},
+		"is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true
+		},
 		"is-glob": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
@@ -1847,12 +1806,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
 			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-			"dev": true
-		},
-		"is-stream": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-			"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
 			"dev": true
 		},
 		"is-typedarray": {
@@ -1971,15 +1924,6 @@
 			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
 			"dev": true
 		},
-		"json-bigint": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
-			"integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
-			"dev": true,
-			"requires": {
-				"bignumber.js": "^9.0.0"
-			}
-		},
 		"json-schema": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -2020,36 +1964,15 @@
 			}
 		},
 		"jszip": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.6.0.tgz",
-			"integrity": "sha512-jgnQoG9LKnWO3mnVNBnfhkh0QknICd1FGSrXcgrl67zioyJ4wgx25o9ZqwNtrROSflGBCGYnJfjrIyRIby1OoQ==",
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.0.tgz",
+			"integrity": "sha512-LDfVtOLtOxb9RXkYOwPyNBTQDL4eUbqahtoY6x07GiDJHwSYvn8sHHIw8wINImV3MqbMNve2gSuM1DDqEKk09Q==",
 			"dev": true,
 			"requires": {
 				"lie": "~3.3.0",
 				"pako": "~1.0.2",
 				"readable-stream": "~2.3.6",
-				"set-immediate-shim": "~1.0.1"
-			}
-		},
-		"jwa": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
-			"integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
-			"dev": true,
-			"requires": {
-				"buffer-equal-constant-time": "1.0.1",
-				"ecdsa-sig-formatter": "1.0.11",
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"jws": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
-			"integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
-			"dev": true,
-			"requires": {
-				"jwa": "^2.0.0",
-				"safe-buffer": "^5.0.1"
+				"setimmediate": "^1.0.5"
 			}
 		},
 		"kind-of": {
@@ -2095,7 +2018,7 @@
 		"lodash.camelcase": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+			"integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
 			"dev": true
 		},
 		"lodash.sortby": {
@@ -2115,15 +2038,6 @@
 			"resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
 			"integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
 			"dev": true
-		},
-		"lru-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"dev": true,
-			"requires": {
-				"yallist": "^4.0.0"
-			}
 		},
 		"magic-string": {
 			"version": "0.25.7",
@@ -2263,16 +2177,37 @@
 			"dev": true
 		},
 		"node-fetch": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-			"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-			"dev": true
-		},
-		"node-forge": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-			"integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
-			"dev": true
+			"version": "2.6.7",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+			"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+			"dev": true,
+			"requires": {
+				"whatwg-url": "^5.0.0"
+			},
+			"dependencies": {
+				"tr46": {
+					"version": "0.0.3",
+					"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+					"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+					"dev": true
+				},
+				"webidl-conversions": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+					"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+					"dev": true
+				},
+				"whatwg-url": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+					"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+					"dev": true,
+					"requires": {
+						"tr46": "~0.0.3",
+						"webidl-conversions": "^3.0.0"
+					}
+				}
+			}
 		},
 		"normalize-path": {
 			"version": "2.1.1",
@@ -3434,10 +3369,16 @@
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
 			"dev": true
 		},
+		"promise-polyfill": {
+			"version": "8.1.3",
+			"resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.3.tgz",
+			"integrity": "sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g==",
+			"dev": true
+		},
 		"protobufjs": {
-			"version": "6.10.2",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.10.2.tgz",
-			"integrity": "sha512-27yj+04uF6ya9l+qfpH187aqEzfCF4+Uit0I9ZBQVqK09hk/SQzKa2MUqUpXaVa7LOFRg1TSSr3lVxGOk6c0SQ==",
+			"version": "6.11.3",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+			"integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
 			"dev": true,
 			"requires": {
 				"@protobufjs/aspromise": "^1.1.2",
@@ -3451,14 +3392,14 @@
 				"@protobufjs/pool": "^1.1.0",
 				"@protobufjs/utf8": "^1.1.0",
 				"@types/long": "^4.0.1",
-				"@types/node": "^13.7.0",
+				"@types/node": ">=13.7.0",
 				"long": "^4.0.0"
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "13.13.48",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.48.tgz",
-					"integrity": "sha512-z8wvSsgWQzkr4sVuMEEOvwMdOQjiRY2Y/ZW4fDfjfe3+TfQrZqFKOthBgk2RnVEmtOKrkwdZ7uTvsxTBLjKGDQ==",
+					"version": "18.0.0",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
+					"integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==",
 					"dev": true
 				}
 			}
@@ -3613,6 +3554,12 @@
 				"tough-cookie": "^2.3.3"
 			}
 		},
+		"require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+			"dev": true
+		},
 		"resolve": {
 			"version": "1.20.0",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
@@ -3624,26 +3571,35 @@
 			}
 		},
 		"rimraf": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
 			"dev": true,
 			"requires": {
 				"glob": "^7.1.3"
 			},
 			"dependencies": {
 				"glob": {
-					"version": "7.1.6",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-					"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+					"version": "7.2.3",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+					"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
 					"dev": true,
 					"requires": {
 						"fs.realpath": "^1.0.0",
 						"inflight": "^1.0.4",
 						"inherits": "2",
-						"minimatch": "^3.0.4",
+						"minimatch": "^3.1.1",
 						"once": "^1.3.0",
 						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"minimatch": {
+					"version": "3.1.2",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+					"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "^1.1.7"
 					}
 				}
 			}
@@ -3816,21 +3772,20 @@
 			}
 		},
 		"selenium-webdriver": {
-			"version": "4.0.0-beta.1",
-			"resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.0.0-beta.1.tgz",
-			"integrity": "sha512-DJ10z6Yk+ZBaLrt1CLElytQ/FOayx29ANKDtmtyW1A6kCJx3+dsc5fFMOZxwzukDniyYsC3OObT5pUAsgkjpxQ==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.1.2.tgz",
+			"integrity": "sha512-e4Ap8vQvhipgBB8Ry9zBiKGkU6kHKyNnWiavGGLKkrdW81Zv7NVMtFOL/j3yX0G8QScM7XIXijKssNd4EUxSOw==",
 			"dev": true,
 			"requires": {
-				"jszip": "^3.5.0",
-				"rimraf": "^2.7.1",
+				"jszip": "^3.6.0",
 				"tmp": "^0.2.1",
-				"ws": "^7.3.1"
+				"ws": ">=7.4.6"
 			},
 			"dependencies": {
 				"ws": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.4.tgz",
-					"integrity": "sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw==",
+					"version": "8.8.0",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-8.8.0.tgz",
+					"integrity": "sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==",
 					"dev": true
 				}
 			}
@@ -3841,10 +3796,10 @@
 			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 			"dev": true
 		},
-		"set-immediate-shim": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+		"setimmediate": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+			"integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
 			"dev": true
 		},
 		"source-map": {
@@ -3898,6 +3853,17 @@
 			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
 			"dev": true
 		},
+		"string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"requires": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			}
+		},
 		"string_decoder": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -3913,6 +3879,15 @@
 					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 					"dev": true
 				}
+			}
+		},
+		"strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "^5.0.1"
 			}
 		},
 		"supports-color": {
@@ -3956,31 +3931,6 @@
 			"dev": true,
 			"requires": {
 				"rimraf": "^3.0.0"
-			},
-			"dependencies": {
-				"glob": {
-					"version": "7.1.6",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-					"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-					"dev": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"rimraf": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				}
 			}
 		},
 		"to-fast-properties": {
@@ -4139,7 +4089,7 @@
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
 			"dev": true
 		},
 		"uuid": {
@@ -4211,6 +4161,12 @@
 				"iconv-lite": "0.4.24"
 			}
 		},
+		"whatwg-fetch": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+			"integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
+			"dev": true
+		},
 		"whatwg-mimetype": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
@@ -4233,6 +4189,43 @@
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
 			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
 			"dev": true
+		},
+		"wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				}
+			}
 		},
 		"wrappy": {
 			"version": "1.0.2",
@@ -4261,16 +4254,31 @@
 			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
 			"dev": true
 		},
-		"xmlhttprequest": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-			"integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=",
+		"y18n": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
 			"dev": true
 		},
-		"yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+		"yargs": {
+			"version": "16.2.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+			"dev": true,
+			"requires": {
+				"cliui": "^7.0.2",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.0",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^20.2.2"
+			}
+		},
+		"yargs-parser": {
+			"version": "20.2.9",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
 			"dev": true
 		},
 		"yn": {

--- a/packages/geofire/package-lock.json
+++ b/packages/geofire/package-lock.json
@@ -5,121 +5,135 @@
 	"requires": true,
 	"dependencies": {
 		"@babel/code-frame": {
-			"version": "7.12.13",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
-			"integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+			"integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
 			"dev": true,
 			"requires": {
-				"@babel/highlight": "^7.12.13"
+				"@babel/highlight": "^7.18.6"
 			}
 		},
 		"@babel/generator": {
-			"version": "7.12.17",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.17.tgz",
-			"integrity": "sha512-DSA7ruZrY4WI8VxuS1jWSRezFnghEoYEFrZcw9BizQRmOZiUsiHl59+qEARGPqPikwA/GPTyRCi7isuCK/oyqg==",
+			"version": "7.18.7",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.7.tgz",
+			"integrity": "sha512-shck+7VLlY72a2w9c3zYWuE1pwOKEiQHV7GTUbSnhyl5eu3i04t30tBY82ZRWrDfo3gkakCFtevExnxbkf2a3A==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.12.17",
-				"jsesc": "^2.5.1",
-				"source-map": "^0.5.0"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-					"dev": true
-				}
+				"@babel/types": "^7.18.7",
+				"@jridgewell/gen-mapping": "^0.3.2",
+				"jsesc": "^2.5.1"
 			}
+		},
+		"@babel/helper-environment-visitor": {
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.6.tgz",
+			"integrity": "sha512-8n6gSfn2baOY+qlp+VSzsosjCVGFqWKmDF0cCWOybh52Dw3SEyoWR1KrhMJASjLwIEkkAufZ0xvr+SxLHSpy2Q==",
+			"dev": true
 		},
 		"@babel/helper-function-name": {
-			"version": "7.12.13",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
-			"integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.18.6.tgz",
+			"integrity": "sha512-0mWMxV1aC97dhjCah5U5Ua7668r5ZmSC2DLfH2EZnf9c3/dHZKiFa5pRLMH5tjSl471tY6496ZWk/kjNONBxhw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-get-function-arity": "^7.12.13",
-				"@babel/template": "^7.12.13",
-				"@babel/types": "^7.12.13"
+				"@babel/template": "^7.18.6",
+				"@babel/types": "^7.18.6"
 			}
 		},
-		"@babel/helper-get-function-arity": {
-			"version": "7.12.13",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
-			"integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+		"@babel/helper-hoist-variables": {
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
+			"integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.12.13"
+				"@babel/types": "^7.18.6"
 			}
 		},
 		"@babel/helper-split-export-declaration": {
-			"version": "7.12.13",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
-			"integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
+			"integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.12.13"
+				"@babel/types": "^7.18.6"
 			}
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-			"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
+			"integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
 			"dev": true
 		},
 		"@babel/highlight": {
-			"version": "7.12.13",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.12.13.tgz",
-			"integrity": "sha512-kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+			"integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.12.11",
+				"@babel/helper-validator-identifier": "^7.18.6",
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
 			}
 		},
 		"@babel/parser": {
-			"version": "7.12.17",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.17.tgz",
-			"integrity": "sha512-r1yKkiUTYMQ8LiEI0UcQx5ETw5dpTLn9wijn9hk6KkTtOK95FndDN10M+8/s6k/Ymlbivw0Av9q4SlgF80PtHg==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.6.tgz",
+			"integrity": "sha512-uQVSa9jJUe/G/304lXspfWVpKpK4euFLgGiMQFOCpM/bgcAdeoHwi/OQz23O9GK2osz26ZiXRRV9aV+Yl1O8tw==",
 			"dev": true
 		},
 		"@babel/template": {
-			"version": "7.12.13",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
-			"integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.6.tgz",
+			"integrity": "sha512-JoDWzPe+wgBsTTgdnIma3iHNFC7YVJoPssVBDjiHfNlyt4YcunDtcDOUmfVDfCK5MfdsaIoX9PkijPhjH3nYUw==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.12.13",
-				"@babel/parser": "^7.12.13",
-				"@babel/types": "^7.12.13"
+				"@babel/code-frame": "^7.18.6",
+				"@babel/parser": "^7.18.6",
+				"@babel/types": "^7.18.6"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.12.17",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.17.tgz",
-			"integrity": "sha512-LGkTqDqdiwC6Q7fWSwQoas/oyiEYw6Hqjve5KOSykXkmFJFqzvGMb9niaUEag3Rlve492Mkye3gLw9FTv94fdQ==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.6.tgz",
+			"integrity": "sha512-zS/OKyqmD7lslOtFqbscH6gMLFYOfG1YPqCKfAW5KrTeolKqvB8UelR49Fpr6y93kYkW2Ik00mT1LOGiAGvizw==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.12.13",
-				"@babel/generator": "^7.12.17",
-				"@babel/helper-function-name": "^7.12.13",
-				"@babel/helper-split-export-declaration": "^7.12.13",
-				"@babel/parser": "^7.12.17",
-				"@babel/types": "^7.12.17",
+				"@babel/code-frame": "^7.18.6",
+				"@babel/generator": "^7.18.6",
+				"@babel/helper-environment-visitor": "^7.18.6",
+				"@babel/helper-function-name": "^7.18.6",
+				"@babel/helper-hoist-variables": "^7.18.6",
+				"@babel/helper-split-export-declaration": "^7.18.6",
+				"@babel/parser": "^7.18.6",
+				"@babel/types": "^7.18.6",
 				"debug": "^4.1.0",
-				"globals": "^11.1.0",
-				"lodash": "^4.17.19"
+				"globals": "^11.1.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.3.4",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+					"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/types": {
-			"version": "7.12.17",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.17.tgz",
-			"integrity": "sha512-tNMDjcv/4DIcHxErTgwB9q2ZcYyN0sUfgGKUK/mm1FJK7Wz+KstoEekxrl/tBiNDgLK1HGi+sppj1An/1DR4fQ==",
+			"version": "7.18.7",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.7.tgz",
+			"integrity": "sha512-QG3yxTcTIBoAcQmkCs+wAPYZhu7Dk9rXKacINfNbdJDNERTbLQbHGyVG8q/YGMPeCJRIhSY0+fTc5+xuh6WPSQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.12.11",
-				"lodash": "^4.17.19",
+				"@babel/helper-validator-identifier": "^7.18.6",
 				"to-fast-properties": "^2.0.0"
 			}
 		},
@@ -134,14 +148,6 @@
 				"@firebase/logger": "0.3.3",
 				"@firebase/util": "1.6.2",
 				"tslib": "^2.1.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-					"dev": true
-				}
 			}
 		},
 		"@firebase/analytics-compat": {
@@ -155,14 +161,6 @@
 				"@firebase/component": "0.5.16",
 				"@firebase/util": "1.6.2",
 				"tslib": "^2.1.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-					"dev": true
-				}
 			}
 		},
 		"@firebase/analytics-types": {
@@ -182,14 +180,6 @@
 				"@firebase/util": "1.6.2",
 				"idb": "7.0.1",
 				"tslib": "^2.1.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-					"dev": true
-				}
 			}
 		},
 		"@firebase/app-check": {
@@ -202,14 +192,6 @@
 				"@firebase/logger": "0.3.3",
 				"@firebase/util": "1.6.2",
 				"tslib": "^2.1.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-					"dev": true
-				}
 			}
 		},
 		"@firebase/app-check-compat": {
@@ -224,14 +206,6 @@
 				"@firebase/logger": "0.3.3",
 				"@firebase/util": "1.6.2",
 				"tslib": "^2.1.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-					"dev": true
-				}
 			}
 		},
 		"@firebase/app-check-interop-types": {
@@ -257,20 +231,12 @@
 				"@firebase/logger": "0.3.3",
 				"@firebase/util": "1.6.2",
 				"tslib": "^2.1.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-					"dev": true
-				}
 			}
 		},
 		"@firebase/app-types": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.6.1.tgz",
-			"integrity": "sha512-L/ZnJRAq7F++utfuoTKX4CLBG5YR7tFO3PLzG1/oXXKEezJ0kRL3CMRoueBEmTCzVb/6SIs2Qlaw++uDgi5Xyg=="
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.6.3.tgz",
+			"integrity": "sha512-/M13DPPati7FQHEQ9Minjk1HGLm/4K4gs9bR4rzLCWJg64yGtVC0zNg9gDpkw9yc2cvol/mNFxqTtd4geGrwdw=="
 		},
 		"@firebase/auth": {
 			"version": "0.20.4",
@@ -284,14 +250,6 @@
 				"node-fetch": "2.6.7",
 				"selenium-webdriver": "4.1.2",
 				"tslib": "^2.1.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-					"dev": true
-				}
 			}
 		},
 		"@firebase/auth-compat": {
@@ -307,14 +265,6 @@
 				"node-fetch": "2.6.7",
 				"selenium-webdriver": "4.1.2",
 				"tslib": "^2.1.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-					"dev": true
-				}
 			}
 		},
 		"@firebase/auth-interop-types": {
@@ -337,14 +287,6 @@
 			"requires": {
 				"@firebase/util": "1.6.2",
 				"tslib": "^2.1.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-					"dev": true
-				}
 			}
 		},
 		"@firebase/database": {
@@ -359,14 +301,6 @@
 				"@firebase/util": "1.6.2",
 				"faye-websocket": "0.11.4",
 				"tslib": "^2.1.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-					"dev": true
-				}
 			}
 		},
 		"@firebase/database-compat": {
@@ -398,21 +332,15 @@
 						"@firebase/app-types": "0.7.0",
 						"@firebase/util": "1.6.2"
 					}
-				},
-				"tslib": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-					"dev": true
 				}
 			}
 		},
 		"@firebase/database-types": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.7.0.tgz",
-			"integrity": "sha512-FduQmPpUUOHgbOt7/vWlC1ntSLMEqqYessdQ/ODd7RFWm53iVa0T1mpIDtNwqd8gW3k7cajjSjcLjfQGtvLGDg==",
+			"version": "0.7.3",
+			"resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.7.3.tgz",
+			"integrity": "sha512-dSOJmhKQ0nL8O4EQMRNGpSExWCXeHtH57gGg0BfNAdWcKhC8/4Y+qfKLfWXzyHvrSecpLmO0SmAi/iK2D5fp5A==",
 			"requires": {
-				"@firebase/app-types": "0.6.1"
+				"@firebase/app-types": "0.6.3"
 			}
 		},
 		"@firebase/firestore": {
@@ -429,14 +357,6 @@
 				"@grpc/proto-loader": "^0.6.0",
 				"node-fetch": "2.6.7",
 				"tslib": "^2.1.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-					"dev": true
-				}
 			}
 		},
 		"@firebase/firestore-compat": {
@@ -450,14 +370,6 @@
 				"@firebase/firestore-types": "2.5.0",
 				"@firebase/util": "1.6.2",
 				"tslib": "^2.1.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-					"dev": true
-				}
 			}
 		},
 		"@firebase/firestore-types": {
@@ -479,14 +391,6 @@
 				"@firebase/util": "1.6.2",
 				"node-fetch": "2.6.7",
 				"tslib": "^2.1.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-					"dev": true
-				}
 			}
 		},
 		"@firebase/functions-compat": {
@@ -500,14 +404,6 @@
 				"@firebase/functions-types": "0.5.0",
 				"@firebase/util": "1.6.2",
 				"tslib": "^2.1.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-					"dev": true
-				}
 			}
 		},
 		"@firebase/functions-types": {
@@ -526,14 +422,6 @@
 				"@firebase/util": "1.6.2",
 				"idb": "7.0.1",
 				"tslib": "^2.1.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-					"dev": true
-				}
 			}
 		},
 		"@firebase/logger": {
@@ -543,14 +431,6 @@
 			"dev": true,
 			"requires": {
 				"tslib": "^2.1.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-					"dev": true
-				}
 			}
 		},
 		"@firebase/messaging": {
@@ -565,14 +445,6 @@
 				"@firebase/util": "1.6.2",
 				"idb": "7.0.1",
 				"tslib": "^2.1.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-					"dev": true
-				}
 			}
 		},
 		"@firebase/messaging-compat": {
@@ -585,14 +457,6 @@
 				"@firebase/messaging": "0.9.15",
 				"@firebase/util": "1.6.2",
 				"tslib": "^2.1.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-					"dev": true
-				}
 			}
 		},
 		"@firebase/messaging-interop-types": {
@@ -612,14 +476,6 @@
 				"@firebase/logger": "0.3.3",
 				"@firebase/util": "1.6.2",
 				"tslib": "^2.1.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-					"dev": true
-				}
 			}
 		},
 		"@firebase/performance-compat": {
@@ -634,14 +490,6 @@
 				"@firebase/performance-types": "0.1.0",
 				"@firebase/util": "1.6.2",
 				"tslib": "^2.1.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-					"dev": true
-				}
 			}
 		},
 		"@firebase/performance-types": {
@@ -672,14 +520,6 @@
 				"@firebase/logger": "0.3.3",
 				"@firebase/util": "1.6.2",
 				"tslib": "^2.1.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-					"dev": true
-				}
 			}
 		},
 		"@firebase/remote-config-compat": {
@@ -694,14 +534,6 @@
 				"@firebase/remote-config-types": "0.2.0",
 				"@firebase/util": "1.6.2",
 				"tslib": "^2.1.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-					"dev": true
-				}
 			}
 		},
 		"@firebase/remote-config-types": {
@@ -720,14 +552,6 @@
 				"@firebase/util": "1.6.2",
 				"node-fetch": "2.6.7",
 				"tslib": "^2.1.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-					"dev": true
-				}
 			}
 		},
 		"@firebase/storage-compat": {
@@ -741,14 +565,6 @@
 				"@firebase/storage-types": "0.6.0",
 				"@firebase/util": "1.6.2",
 				"tslib": "^2.1.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-					"dev": true
-				}
 			}
 		},
 		"@firebase/storage-types": {
@@ -764,14 +580,6 @@
 			"dev": true,
 			"requires": {
 				"tslib": "^2.1.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-					"dev": true
-				}
 			}
 		},
 		"@firebase/webchannel-wrapper": {
@@ -809,6 +617,45 @@
 				"long": "^4.0.0",
 				"protobufjs": "^6.11.3",
 				"yargs": "^16.2.0"
+			}
+		},
+		"@jridgewell/gen-mapping": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+			"integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+			"dev": true,
+			"requires": {
+				"@jridgewell/set-array": "^1.0.1",
+				"@jridgewell/sourcemap-codec": "^1.4.10",
+				"@jridgewell/trace-mapping": "^0.3.9"
+			}
+		},
+		"@jridgewell/resolve-uri": {
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.8.tgz",
+			"integrity": "sha512-YK5G9LaddzGbcucK4c8h5tWFmMPBvRZ/uyWmN1/SbBdIvqGUdWGkJ5BAaccgs6XbzVLsqbPJrBSFwKv3kT9i7w==",
+			"dev": true
+		},
+		"@jridgewell/set-array": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+			"dev": true
+		},
+		"@jridgewell/sourcemap-codec": {
+			"version": "1.4.14",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+			"dev": true
+		},
+		"@jridgewell/trace-mapping": {
+			"version": "0.3.14",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
+			"integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+			"dev": true,
+			"requires": {
+				"@jridgewell/resolve-uri": "^3.0.3",
+				"@jridgewell/sourcemap-codec": "^1.4.10"
 			}
 		},
 		"@protobufjs/aspromise": {
@@ -876,15 +723,15 @@
 			"dev": true
 		},
 		"@types/chai": {
-			"version": "4.2.15",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.15.tgz",
-			"integrity": "sha512-rYff6FI+ZTKAPkJUoyz7Udq3GaoDZnxYDEvdEdFZASiA7PoErltHezDishqQiSDWrGxvxmplH304jyzQmjp0AQ==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.1.tgz",
+			"integrity": "sha512-/zPMqDkzSZ8t3VtxOa4KPq7uzzW978M9Tvh+j7GHKuo6k6GTLxPJ4J5gE5cjfJ26pnXst0N5Hax8Sr0T2Mi9zQ==",
 			"dev": true
 		},
 		"@types/estree": {
-			"version": "0.0.46",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
-			"integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg==",
+			"version": "0.0.52",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.52.tgz",
+			"integrity": "sha512-BZWrtCU0bMVAIliIV+HJO1f1PR41M7NKjfxrFJwwhKI1KwhwOxYw1SXg9ao+CIMt774nFuGiG6eU+udtbEI9oQ==",
 			"dev": true
 		},
 		"@types/long": {
@@ -900,9 +747,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "10.17.53",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.53.tgz",
-			"integrity": "sha512-q1igVlMUU+10kzjxNlcLDH7gekuvFK1nevnp7MAyc6sqvK5siWSS37EuvKX9fM8d49SBcoP0iP9tqVHmdAjNhQ==",
+			"version": "10.17.60",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+			"integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
 			"dev": true
 		},
 		"@types/resolve": {
@@ -915,9 +762,9 @@
 			}
 		},
 		"abab": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
-			"integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
+			"integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
 			"dev": true
 		},
 		"acorn": {
@@ -961,12 +808,12 @@
 			"dev": true
 		},
 		"ansi-styles": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 			"dev": true,
 			"requires": {
-				"color-convert": "^1.9.0"
+				"color-convert": "^2.0.1"
 			}
 		},
 		"arg": {
@@ -987,7 +834,7 @@
 		"arr-diff": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+			"integrity": "sha512-dtXTVMkh6VkEEA7OhXnN1Ecb8aAGFdZ1LFxtOCoqj4qkyOJMt7+qs6Ahdy6p/NQCPYsRSXXivhSB/J5E9jmYKA==",
 			"dev": true,
 			"requires": {
 				"arr-flatten": "^1.0.1"
@@ -1002,19 +849,19 @@
 		"array-equal": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+			"integrity": "sha512-H3LU5RLiSsGXPhN+Nipar0iR0IofH+8r89G2y1tBKxQ/agagKyAjhkAFDRBfodP2caPrNKHpAWNIM/c9yeL7uA==",
 			"dev": true
 		},
 		"array-unique": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+			"integrity": "sha512-G2n5bG5fSUCpnsXz4+8FUkYsGPkNfLn9YvS66U5qbTIXI2Ynnlo4Bi42bWv+omKUCqz+ejzfClwne0alJWJPhg==",
 			"dev": true
 		},
 		"asn1": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+			"version": "0.2.6",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+			"integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
 			"dev": true,
 			"requires": {
 				"safer-buffer": "~2.1.0"
@@ -1023,7 +870,7 @@
 		"assert-plus": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+			"integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
 			"dev": true
 		},
 		"assertion-error": {
@@ -1041,13 +888,13 @@
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
 			"dev": true
 		},
 		"aws-sign2": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+			"integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
 			"dev": true
 		},
 		"aws4": {
@@ -1057,15 +904,15 @@
 			"dev": true
 		},
 		"balanced-match": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true
 		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+			"integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
 			"dev": true,
 			"requires": {
 				"tweetnacl": "^0.14.3"
@@ -1084,7 +931,7 @@
 		"braces": {
 			"version": "1.8.5",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+			"integrity": "sha512-xU7bpz2ytJl1bH9cgIurjpg/n8Gohy9GTw81heDYLJQ4RU60dlyJsa+atVF2pI0yMMvKxI9HkKwjePCj5XI1hw==",
 			"dev": true,
 			"requires": {
 				"expand-range": "^1.8.1",
@@ -1105,34 +952,35 @@
 			"dev": true
 		},
 		"buffer-from": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
 			"dev": true
 		},
 		"builtin-modules": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.2.0.tgz",
-			"integrity": "sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+			"integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
 			"dev": true
 		},
 		"caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+			"integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
 			"dev": true
 		},
 		"chai": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.0.tgz",
-			"integrity": "sha512-/BFd2J30EcOwmdOgXvVsmM48l0Br0nmZPlO0uOW4XKh6kpsUumRXBgPV+IlaqFaqr9cYbeoZAM1Npx0i4A+aiA==",
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
+			"integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
 			"dev": true,
 			"requires": {
 				"assertion-error": "^1.1.0",
 				"check-error": "^1.0.2",
 				"deep-eql": "^3.0.1",
 				"get-func-name": "^2.0.0",
-				"pathval": "^1.1.0",
+				"loupe": "^2.3.1",
+				"pathval": "^1.1.1",
 				"type-detect": "^4.0.5"
 			}
 		},
@@ -1145,12 +993,38 @@
 				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
 				"supports-color": "^5.3.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+					"dev": true
+				}
 			}
 		},
 		"check-error": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+			"integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
 			"dev": true
 		},
 		"cliui": {
@@ -1165,18 +1039,18 @@
 			}
 		},
 		"color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
 			"dev": true,
 			"requires": {
-				"color-name": "1.1.3"
+				"color-name": "~1.1.4"
 			}
 		},
 		"color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true
 		},
 		"combined-stream": {
@@ -1197,7 +1071,7 @@
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
 			"dev": true
 		},
 		"core-js": {
@@ -1209,13 +1083,13 @@
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
 			"dev": true
 		},
 		"coveralls": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.1.0.tgz",
-			"integrity": "sha512-sHxOu2ELzW8/NC1UP5XVLbZDzO4S3VxfFye3XYCznopHy02YjNkHcj5bKaVw2O7hVaBdBjEdQGpie4II1mWhuQ==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.1.1.tgz",
+			"integrity": "sha512-+dxnG2NHncSD1NrqbSM3dn/lE57O6Qf/koe9+I7c+wzkqRmEvcp0kgJdxKInzYzkICKkFMZsX3Vct3++tsF9ww==",
 			"dev": true,
 			"requires": {
 				"js-yaml": "^3.13.1",
@@ -1243,7 +1117,7 @@
 		"dashdash": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
 			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
@@ -1258,15 +1132,43 @@
 				"abab": "^2.0.0",
 				"whatwg-mimetype": "^2.2.0",
 				"whatwg-url": "^7.0.0"
+			},
+			"dependencies": {
+				"tr46": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+					"integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
+					"dev": true,
+					"requires": {
+						"punycode": "^2.1.0"
+					}
+				},
+				"webidl-conversions": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+					"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+					"dev": true
+				},
+				"whatwg-url": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+					"integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+					"dev": true,
+					"requires": {
+						"lodash.sortby": "^4.7.0",
+						"tr46": "^1.0.1",
+						"webidl-conversions": "^4.0.2"
+					}
+				}
 			}
 		},
 		"debug": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-			"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
 			"dev": true,
 			"requires": {
-				"ms": "2.1.2"
+				"ms": "2.0.0"
 			}
 		},
 		"deep-eql": {
@@ -1279,15 +1181,15 @@
 			}
 		},
 		"deep-is": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
 			"dev": true
 		},
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
 			"dev": true
 		},
 		"diff": {
@@ -1303,12 +1205,20 @@
 			"dev": true,
 			"requires": {
 				"webidl-conversions": "^4.0.2"
+			},
+			"dependencies": {
+				"webidl-conversions": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+					"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+					"dev": true
+				}
 			}
 		},
 		"ecc-jsbn": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+			"integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
 			"dev": true,
 			"requires": {
 				"jsbn": "~0.1.0",
@@ -1330,7 +1240,7 @@
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
 			"dev": true
 		},
 		"escodegen": {
@@ -1373,7 +1283,7 @@
 		"expand-brackets": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+			"integrity": "sha512-hxx03P2dJxss6ceIeri9cmYOT4SRs3Zk3afZwWpOsRqLqprhTR8u++SlC+sFGsQr7WGFPdMF7Gjc1njDLDK6UA==",
 			"dev": true,
 			"requires": {
 				"is-posix-bracket": "^0.1.0"
@@ -1382,7 +1292,7 @@
 		"expand-range": {
 			"version": "1.8.2",
 			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+			"integrity": "sha512-AFASGfIlnIbkKPQwX1yHaDjFvh/1gyKJODme52V6IORh69uEYgZp0o9C+qsIGNVEiuuhQU0CSSl++Rlegg1qvA==",
 			"dev": true,
 			"requires": {
 				"fill-range": "^2.1.0"
@@ -1397,7 +1307,7 @@
 		"extglob": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+			"integrity": "sha512-1FOj1LOwn42TMrruOHGt18HemVnbwAmAak7krWk+wa93KXxGbK+2jpezm+ytJYDaBX0/SPLZFHKM7m+tKobWGg==",
 			"dev": true,
 			"requires": {
 				"is-extglob": "^1.0.0"
@@ -1406,7 +1316,7 @@
 		"extsprintf": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+			"integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
 			"dev": true
 		},
 		"fast-deep-equal": {
@@ -1424,7 +1334,7 @@
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
 			"dev": true
 		},
 		"faye-websocket": {
@@ -1439,7 +1349,7 @@
 		"filename-regex": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+			"integrity": "sha512-BTCqyBaWBTsauvnHiE8i562+EdJj+oUpkqWp2R1iCoR8f6oo8STRu3of7WJJ0TqWtxN50a5YFpzYK4Jj9esYfQ==",
 			"dev": true
 		},
 		"fill-range": {
@@ -1500,13 +1410,13 @@
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+			"integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==",
 			"dev": true
 		},
 		"for-own": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+			"integrity": "sha512-SKmowqGTJoPzLO1T0BBJpkfp3EMacCMOuH40hOUbrbzElVktk4DioXVM99QkLCyKoiuOmyjgcWMpVz2xjE7LZw==",
 			"dev": true,
 			"requires": {
 				"for-in": "^1.0.1"
@@ -1515,7 +1425,7 @@
 		"forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+			"integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
 			"dev": true
 		},
 		"form-data": {
@@ -1543,7 +1453,7 @@
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
 			"dev": true
 		},
 		"function-bind": {
@@ -1561,28 +1471,28 @@
 		"get-func-name": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+			"integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
 			"dev": true
 		},
 		"getpass": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
 			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
 			}
 		},
 		"glob": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
 			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
 				"inherits": "2",
-				"minimatch": "^3.0.4",
+				"minimatch": "^3.1.1",
 				"once": "^1.3.0",
 				"path-is-absolute": "^1.0.0"
 			}
@@ -1590,7 +1500,7 @@
 		"glob-base": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+			"integrity": "sha512-ab1S1g1EbO7YzauaJLkgLp7DZVAqj9M/dvKlTt8DkXA2tiOIcSMrlVI2J1RZyB5iJVccEscjGn+kpOG9788MHA==",
 			"dev": true,
 			"requires": {
 				"glob-parent": "^2.0.0",
@@ -1600,7 +1510,7 @@
 		"glob-parent": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+			"integrity": "sha512-JDYOvfxio/t42HKdxkAYaCiBN7oYiuxykOxKxdaUW5Qn0zaYN3gRQWolrwdnf0shM9/EP0ebuuTmyoXNr1cC5w==",
 			"dev": true,
 			"requires": {
 				"is-glob": "^2.0.0"
@@ -1613,9 +1523,9 @@
 			"dev": true
 		},
 		"graceful-fs": {
-			"version": "4.2.6",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-			"integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+			"version": "4.2.10",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+			"integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
 			"dev": true
 		},
 		"growl": {
@@ -1627,7 +1537,7 @@
 		"har-schema": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+			"integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
 			"dev": true
 		},
 		"har-validator": {
@@ -1652,19 +1562,13 @@
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
 			"dev": true
 		},
 		"he": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
-			"dev": true
-		},
-		"hosted-git-info": {
-			"version": "2.8.9",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-			"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+			"integrity": "sha512-z/GDPjlRMNOa2XJiB4em8wJpuuBfrFOlYKTZxtpkdr1uPdibHI8rYA3MY0KDObpVyaes0e/aunid/t88ZI2EKA==",
 			"dev": true
 		},
 		"html-encoding-sniffer": {
@@ -1685,7 +1589,7 @@
 		"http-signature": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+			"integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
 			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
@@ -1717,7 +1621,7 @@
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
 			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
@@ -1737,9 +1641,9 @@
 			"dev": true
 		},
 		"is-core-module": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
-			"integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+			"integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
 			"dev": true,
 			"requires": {
 				"has": "^1.0.3"
@@ -1748,13 +1652,13 @@
 		"is-dotfile": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+			"integrity": "sha512-9YclgOGtN/f8zx0Pr4FQYMdibBiTaH3sn52vjYip4ZSf6C4/6RfTEZ+MR4GvKhCxdPh21Bg42/WL55f6KSnKpg==",
 			"dev": true
 		},
 		"is-equal-shallow": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+			"integrity": "sha512-0EygVC5qPvIyb+gSz7zdD5/AAoS6Qrx1e//6N4yv4oNm30kqvdmG66oZFWVlQHUWe5OjP08FuTw2IdT0EOTcYA==",
 			"dev": true,
 			"requires": {
 				"is-primitive": "^2.0.0"
@@ -1763,13 +1667,13 @@
 		"is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
 			"dev": true
 		},
 		"is-extglob": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+			"integrity": "sha512-7Q+VbVafe6x2T+Tu6NcOf6sRklazEPmBoB3IWk3WdGZM2iGUwU/Oe3Wtq5lSEkDTTlpp8yx+5t4pzO/i9Ty1ww==",
 			"dev": true
 		},
 		"is-fullwidth-code-point": {
@@ -1781,7 +1685,7 @@
 		"is-glob": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+			"integrity": "sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg==",
 			"dev": true,
 			"requires": {
 				"is-extglob": "^1.0.0"
@@ -1790,13 +1694,13 @@
 		"is-module": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
-			"integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
+			"integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
 			"dev": true
 		},
 		"is-number": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+			"integrity": "sha512-QUzH43Gfb9+5yckcrSA0VBDwEtDUchrk4F6tfJZQuNzDJbEDB9cZNzSfXGQ1jqmdDY/kl41lUOWM9syA8z8jlg==",
 			"dev": true,
 			"requires": {
 				"kind-of": "^3.0.2"
@@ -1805,31 +1709,31 @@
 		"is-posix-bracket": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+			"integrity": "sha512-Yu68oeXJ7LeWNmZ3Zov/xg/oDBnBK2RNxwYY1ilNJX+tKKZqgPK+qOn/Gs9jEu66KDY9Netf5XLKNGzas/vPfQ==",
 			"dev": true
 		},
 		"is-primitive": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+			"integrity": "sha512-N3w1tFaRfk3UrPfqeRyD+GYDASU3W5VinKhlORy8EWVf/sIdDL9GAcew85XmktCfH+ngG7SRXEVDoO18WMdB/Q==",
 			"dev": true
 		},
 		"is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+			"integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
 			"dev": true
 		},
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
 			"dev": true
 		},
 		"isobject": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+			"integrity": "sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==",
 			"dev": true,
 			"requires": {
 				"isarray": "1.0.0"
@@ -1838,7 +1742,7 @@
 		"isstream": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+			"integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
 			"dev": true
 		},
 		"istanbul-lib-coverage": {
@@ -1862,6 +1766,34 @@
 				"semver": "^6.0.0"
 			}
 		},
+		"jest-worker": {
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
+			"integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*",
+				"merge-stream": "^2.0.0",
+				"supports-color": "^7.0.0"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
 		"js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -1881,7 +1813,7 @@
 		"jsbn": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
 			"dev": true
 		},
 		"jsdom": {
@@ -1916,12 +1848,49 @@
 				"whatwg-url": "^7.0.0",
 				"ws": "^6.1.2",
 				"xml-name-validator": "^3.0.0"
+			},
+			"dependencies": {
+				"tr46": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+					"integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
+					"dev": true,
+					"requires": {
+						"punycode": "^2.1.0"
+					}
+				},
+				"webidl-conversions": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+					"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+					"dev": true
+				},
+				"whatwg-url": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+					"integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+					"dev": true,
+					"requires": {
+						"lodash.sortby": "^4.7.0",
+						"tr46": "^1.0.1",
+						"webidl-conversions": "^4.0.2"
+					}
+				},
+				"ws": {
+					"version": "6.2.2",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-6.2.2.tgz",
+					"integrity": "sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==",
+					"dev": true,
+					"requires": {
+						"async-limiter": "~1.0.0"
+					}
+				}
 			}
 		},
 		"jsdom-global": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/jsdom-global/-/jsdom-global-3.0.2.tgz",
-			"integrity": "sha1-a9KZwTsMRiay2iwDk81DhdYGrLk=",
+			"integrity": "sha512-t1KMcBkz/pT5JrvcJbpUR2u/w1kO9jXctaaGJ0vZDzwFnIvGWw9IDSRciT83kIs8Bnw4qpOl8bQK08V01YgMPg==",
 			"dev": true
 		},
 		"jsesc": {
@@ -1931,9 +1900,9 @@
 			"dev": true
 		},
 		"json-schema": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+			"integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
 			"dev": true
 		},
 		"json-schema-traverse": {
@@ -1945,27 +1914,27 @@
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+			"integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
 			"dev": true
 		},
 		"jsonfile": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+			"integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.6"
 			}
 		},
 		"jsprim": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+			"integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
 			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"extsprintf": "1.3.0",
-				"json-schema": "0.2.3",
+				"json-schema": "0.4.0",
 				"verror": "1.10.0"
 			}
 		},
@@ -1984,7 +1953,7 @@
 		"kind-of": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
 			"dev": true,
 			"requires": {
 				"is-buffer": "^1.1.5"
@@ -1993,13 +1962,13 @@
 		"lcov-parse": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
-			"integrity": "sha1-6w1GtUER68VhrLTECO+TY73I9+A=",
+			"integrity": "sha512-aprLII/vPzuQvYZnDRU78Fns9I2Ag3gi4Ipga/hxnVMCZC8DnR2nI7XBqrPoywGfxqIx/DgarGvDJZAD3YBTgQ==",
 			"dev": true
 		},
 		"levn": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
 			"dev": true,
 			"requires": {
 				"prelude-ls": "~1.1.2",
@@ -2018,7 +1987,8 @@
 		"lodash": {
 			"version": "4.17.21",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+			"dev": true
 		},
 		"lodash.camelcase": {
 			"version": "4.3.0",
@@ -2029,7 +1999,7 @@
 		"lodash.sortby": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+			"integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
 			"dev": true
 		},
 		"log-driver": {
@@ -2044,13 +2014,22 @@
 			"integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
 			"dev": true
 		},
-		"magic-string": {
-			"version": "0.25.7",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
-			"integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+		"loupe": {
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz",
+			"integrity": "sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==",
 			"dev": true,
 			"requires": {
-				"sourcemap-codec": "^1.4.4"
+				"get-func-name": "^2.0.0"
+			}
+		},
+		"magic-string": {
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+			"integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+			"dev": true,
+			"requires": {
+				"sourcemap-codec": "^1.4.8"
 			}
 		},
 		"make-error": {
@@ -2074,7 +2053,7 @@
 		"micromatch": {
 			"version": "2.3.11",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+			"integrity": "sha512-LnU2XFEk9xxSJ6rfgAry/ty5qwUTyHYOBU0g4R6tIw5ljwgGIBmiKhRWLw5NpMOnrgUNcDJ4WMp8rl3sYVHLNA==",
 			"dev": true,
 			"requires": {
 				"arr-diff": "^2.0.0",
@@ -2093,39 +2072,39 @@
 			}
 		},
 		"mime-db": {
-			"version": "1.46.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.46.0.tgz",
-			"integrity": "sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ==",
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
 			"dev": true
 		},
 		"mime-types": {
-			"version": "2.1.29",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.29.tgz",
-			"integrity": "sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==",
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
 			"dev": true,
 			"requires": {
-				"mime-db": "1.46.0"
+				"mime-db": "1.52.0"
 			}
 		},
 		"minimatch": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
 			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
 		},
 		"minimist": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
 			"dev": true
 		},
 		"mkdirp": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"integrity": "sha512-SknJC52obPfGQPnjIkXbmA6+5H15E+fR+E4iR2oQ3zzCLbd7/ONua69R/Gw7AgkTLsRG+r5fzksYwWe1AgTyWA==",
 			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
@@ -2134,7 +2113,7 @@
 				"minimist": {
 					"version": "0.0.8",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+					"integrity": "sha512-miQKw5Hv4NS1Psg2517mV4e4dYNaO3++hjAvLOAzKqZ61rH8NS1SK+vbfBWZ5PY/Me/bEWhUwqMghEW5Fb9T7Q==",
 					"dev": true
 				}
 			}
@@ -2158,33 +2137,35 @@
 				"supports-color": "5.4.0"
 			},
 			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+				"glob": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 					"dev": true,
 					"requires": {
-						"ms": "2.0.0"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
+				"minimatch": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "^1.1.7"
+					}
 				}
 			}
 		},
 		"ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
-		},
-		"neo-async": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 			"dev": true
 		},
 		"node-fetch": {
@@ -2194,45 +2175,21 @@
 			"dev": true,
 			"requires": {
 				"whatwg-url": "^5.0.0"
-			},
-			"dependencies": {
-				"tr46": {
-					"version": "0.0.3",
-					"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-					"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-					"dev": true
-				},
-				"webidl-conversions": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-					"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-					"dev": true
-				},
-				"whatwg-url": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-					"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-					"dev": true,
-					"requires": {
-						"tr46": "~0.0.3",
-						"webidl-conversions": "^3.0.0"
-					}
-				}
 			}
 		},
 		"normalize-path": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+			"integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
 			"dev": true,
 			"requires": {
 				"remove-trailing-separator": "^1.0.1"
 			}
 		},
 		"nwsapi": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
-			"integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.1.tgz",
+			"integrity": "sha512-JYOWTeFoS0Z93587vRJgASD5Ut11fYl5NyihP3KrYBvMe1FRRs6RN7m20SA/16GM4P6hTnZjT+UmDOt38UeXNg==",
 			"dev": true
 		},
 		"nyc": {
@@ -2293,6 +2250,7 @@
 				"async": {
 					"version": "2.6.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"lodash": "^4.17.11"
 					}
@@ -2345,6 +2303,7 @@
 				"commander": {
 					"version": "2.17.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"commondir": {
@@ -2507,6 +2466,24 @@
 					"bundled": true,
 					"dev": true
 				},
+				"handlebars": {
+					"version": "4.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"async": "^2.5.0",
+						"optimist": "^0.6.1",
+						"source-map": "^0.6.1",
+						"uglify-js": "^3.1.4"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.6.1",
+							"bundled": true,
+							"dev": true
+						}
+					}
+				},
 				"has-flag": {
 					"version": "3.0.0",
 					"bundled": true,
@@ -2519,6 +2496,11 @@
 					"requires": {
 						"is-stream": "^1.0.1"
 					}
+				},
+				"hosted-git-info": {
+					"version": "2.7.1",
+					"bundled": true,
+					"dev": true
 				},
 				"imurmurhash": {
 					"version": "0.1.4",
@@ -2657,6 +2639,11 @@
 						"path-exists": "^3.0.0"
 					}
 				},
+				"lodash": {
+					"version": "4.17.11",
+					"bundled": true,
+					"dev": true
+				},
 				"lodash.flattendeep": {
 					"version": "4.4.0",
 					"bundled": true,
@@ -2727,7 +2714,8 @@
 				},
 				"minimist": {
 					"version": "0.0.10",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"mkdirp": {
 					"version": "0.5.1",
@@ -2789,6 +2777,7 @@
 				"optimist": {
 					"version": "0.6.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"minimist": "~0.0.1",
 						"wordwrap": "~0.0.2"
@@ -2877,6 +2866,11 @@
 				},
 				"path-key": {
 					"version": "2.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"path-parse": {
+					"version": "1.0.6",
 					"bundled": true,
 					"dev": true
 				},
@@ -3088,6 +3082,8 @@
 				"uglify-js": {
 					"version": "3.4.9",
 					"bundled": true,
+					"dev": true,
+					"optional": true,
 					"requires": {
 						"commander": "~2.17.1",
 						"source-map": "~0.6.1"
@@ -3096,6 +3092,7 @@
 						"source-map": {
 							"version": "0.6.1",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
@@ -3129,7 +3126,8 @@
 				},
 				"wordwrap": {
 					"version": "0.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"wrap-ansi": {
 					"version": "2.1.0",
@@ -3188,6 +3186,11 @@
 						"signal-exit": "^3.0.2"
 					}
 				},
+				"y18n": {
+					"version": "4.0.0",
+					"bundled": true,
+					"dev": true
+				},
 				"yallist": {
 					"version": "2.1.2",
 					"bundled": true,
@@ -3232,7 +3235,7 @@
 		"object.omit": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+			"integrity": "sha512-UiAM5mhmIuKLsOvrL+B0U2d1hXHF3bFYWIuH1LMpuV2EJEHG1Ntz06PgLEHjm6VFd87NpH8rastvPoyv6UW2fA==",
 			"dev": true,
 			"requires": {
 				"for-own": "^0.1.4",
@@ -3242,7 +3245,7 @@
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
 			"dev": true,
 			"requires": {
 				"wrappy": "1"
@@ -3271,7 +3274,7 @@
 		"parse-glob": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+			"integrity": "sha512-FC5TeK0AwXzq3tUBFtH74naWkPQCEWs4K+xMxWZBlKDWu0bVHXGZa+KKqxKidd7xwhdZ19ZNuF2uO1M/r196HA==",
 			"dev": true,
 			"requires": {
 				"glob-base": "^0.3.0",
@@ -3289,7 +3292,7 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
 			"dev": true
 		},
 		"path-parse": {
@@ -3307,7 +3310,7 @@
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+			"integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
 			"dev": true
 		},
 		"pn": {
@@ -3319,13 +3322,13 @@
 		"prelude-ls": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+			"integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
 			"dev": true
 		},
 		"preserve": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+			"integrity": "sha512-s/46sYeylUfHNjI+sA/78FAHlmIuKqI9wNnzEOGehAlUUYeObv5C2mOinXBjyUyWmJ2SfcS2/ydApH4hTF4WXQ==",
 			"dev": true
 		},
 		"process-nextick-args": {
@@ -3382,9 +3385,9 @@
 			"dev": true
 		},
 		"qs": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+			"integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
 			"dev": true
 		},
 		"randomatic": {
@@ -3456,19 +3459,19 @@
 		"remove-trailing-separator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+			"integrity": "sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==",
 			"dev": true
 		},
 		"repeat-element": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
-			"integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.4.tgz",
+			"integrity": "sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==",
 			"dev": true
 		},
 		"repeat-string": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+			"integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
 			"dev": true
 		},
 		"request": {
@@ -3526,13 +3529,14 @@
 			"dev": true
 		},
 		"resolve": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-			"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+			"version": "1.22.1",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+			"integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
 			"dev": true,
 			"requires": {
-				"is-core-module": "^2.2.0",
-				"path-parse": "^1.0.6"
+				"is-core-module": "^2.9.0",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
 			}
 		},
 		"rimraf": {
@@ -3542,31 +3546,6 @@
 			"dev": true,
 			"requires": {
 				"glob": "^7.1.3"
-			},
-			"dependencies": {
-				"glob": {
-					"version": "7.2.3",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-					"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-					"dev": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.1.1",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"minimatch": {
-					"version": "3.1.2",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-					"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-					"dev": true,
-					"requires": {
-						"brace-expansion": "^1.1.7"
-					}
-				}
 			}
 		},
 		"rollup": {
@@ -3622,43 +3601,6 @@
 				"jest-worker": "^26.0.0",
 				"serialize-javascript": "^3.0.0",
 				"terser": "^4.7.0"
-			},
-			"dependencies": {
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"jest-worker": {
-					"version": "26.6.2",
-					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
-					"integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
-					"dev": true,
-					"requires": {
-						"@types/node": "*",
-						"merge-stream": "^2.0.0",
-						"supports-color": "^7.0.0"
-					}
-				},
-				"serialize-javascript": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-3.1.0.tgz",
-					"integrity": "sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==",
-					"dev": true,
-					"requires": {
-						"randombytes": "^2.1.0"
-					}
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
 			}
 		},
 		"rollup-plugin-typescript2": {
@@ -3745,14 +3687,6 @@
 				"jszip": "^3.6.0",
 				"tmp": "^0.2.1",
 				"ws": ">=7.4.6"
-			},
-			"dependencies": {
-				"ws": {
-					"version": "8.8.0",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-8.8.0.tgz",
-					"integrity": "sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==",
-					"dev": true
-				}
 			}
 		},
 		"semver": {
@@ -3760,6 +3694,15 @@
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
 			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 			"dev": true
+		},
+		"serialize-javascript": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-3.1.0.tgz",
+			"integrity": "sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==",
+			"dev": true,
+			"requires": {
+				"randombytes": "^2.1.0"
+			}
 		},
 		"setimmediate": {
 			"version": "1.0.5",
@@ -3774,9 +3717,9 @@
 			"dev": true
 		},
 		"source-map-support": {
-			"version": "0.5.19",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-			"integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+			"version": "0.5.21",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
 			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
@@ -3792,13 +3735,13 @@
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
 			"dev": true
 		},
 		"sshpk": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
+			"integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
 			"dev": true,
 			"requires": {
 				"asn1": "~0.2.3",
@@ -3815,7 +3758,7 @@
 		"stealthy-require": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+			"integrity": "sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g==",
 			"dev": true
 		},
 		"string-width": {
@@ -3864,6 +3807,12 @@
 				"has-flag": "^3.0.0"
 			}
 		},
+		"supports-preserve-symlinks-flag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+			"dev": true
+		},
 		"symbol-tree": {
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -3901,7 +3850,7 @@
 		"to-fast-properties": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+			"integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
 			"dev": true
 		},
 		"tough-cookie": {
@@ -3915,13 +3864,10 @@
 			}
 		},
 		"tr46": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-			"dev": true,
-			"requires": {
-				"punycode": "^2.1.0"
-			}
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+			"dev": true
 		},
 		"ts-node": {
 			"version": "8.10.2",
@@ -3945,9 +3891,9 @@
 			}
 		},
 		"tslib": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 			"dev": true
 		},
 		"tslint": {
@@ -3974,7 +3920,7 @@
 				"builtin-modules": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-					"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+					"integrity": "sha512-wxXCdllwGhI2kCC0MnvTGYTMvnVZTvqgypkiTI8Pa5tcz2i6VqsqwYGgqwXji+4RgCzms6EajE4IxiUH6HH8nQ==",
 					"dev": true
 				},
 				"diff": {
@@ -3988,6 +3934,12 @@
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
 					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
 					"dev": true
+				},
+				"tslib": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+					"dev": true
 				}
 			}
 		},
@@ -3998,12 +3950,20 @@
 			"dev": true,
 			"requires": {
 				"tslib": "^1.8.1"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+					"dev": true
+				}
 			}
 		},
 		"tunnel-agent": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
 			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.0.1"
@@ -4012,13 +3972,13 @@
 		"tweetnacl": {
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
 			"dev": true
 		},
 		"type-check": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
 			"dev": true,
 			"requires": {
 				"prelude-ls": "~1.1.2"
@@ -4031,9 +3991,9 @@
 			"dev": true
 		},
 		"typescript": {
-			"version": "3.9.9",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
-			"integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==",
+			"version": "3.9.10",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+			"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
 			"dev": true
 		},
 		"universalify": {
@@ -4066,7 +4026,7 @@
 		"verror": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
 			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
@@ -4092,12 +4052,20 @@
 				"domexception": "^1.0.1",
 				"webidl-conversions": "^4.0.2",
 				"xml-name-validator": "^3.0.0"
+			},
+			"dependencies": {
+				"webidl-conversions": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+					"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+					"dev": true
+				}
 			}
 		},
 		"webidl-conversions": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
 			"dev": true
 		},
 		"websocket-driver": {
@@ -4139,14 +4107,13 @@
 			"dev": true
 		},
 		"whatwg-url": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-			"integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
 			"dev": true,
 			"requires": {
-				"lodash.sortby": "^4.7.0",
-				"tr46": "^1.0.1",
-				"webidl-conversions": "^4.0.2"
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
 			}
 		},
 		"word-wrap": {
@@ -4164,48 +4131,19 @@
 				"ansi-styles": "^4.0.0",
 				"string-width": "^4.1.0",
 				"strip-ansi": "^6.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				}
 			}
 		},
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
 			"dev": true
 		},
 		"ws": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-6.2.2.tgz",
-			"integrity": "sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==",
-			"dev": true,
-			"requires": {
-				"async-limiter": "~1.0.0"
-			}
+			"version": "8.8.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.8.0.tgz",
+			"integrity": "sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==",
+			"dev": true
 		},
 		"xml-name-validator": {
 			"version": "3.0.0",

--- a/packages/geofire/package.json
+++ b/packages/geofire/package.json
@@ -59,7 +59,7 @@
     "rollup-plugin-commonjs": "^9.2.0",
     "rollup-plugin-node-resolve": "^4.0.0",
     "rollup-plugin-typescript2": "^0.19.2",
-    "rollup-plugin-uglify": "^6.0.2",
+    "rollup-plugin-terser": "^6.0.2",
     "source-map-support": "^0.5.10",
     "ts-node": "^8.0.2",
     "tslint": "^5.12.1",

--- a/packages/geofire/package.json
+++ b/packages/geofire/package.json
@@ -42,7 +42,7 @@
     "geofire-common": "5.2.0"
   },
   "peerDependencies": {
-    "firebase": "9.0.0-beta.1"
+    "firebase": "9.x.x"
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",
@@ -50,7 +50,7 @@
     "@types/node": "^10.12.21",
     "chai": "^4.2.0",
     "coveralls": "^3.0.2",
-    "firebase": "9.0.0-beta.1",
+    "firebase": "^9.0.0",
     "jsdom": "^13.2.0",
     "jsdom-global": "^3.0.2",
     "mocha": "^5.2.0",

--- a/packages/geofire/package.json
+++ b/packages/geofire/package.json
@@ -42,7 +42,7 @@
     "geofire-common": "5.2.0"
   },
   "peerDependencies": {
-    "firebase": "^2.4.0 || 3.x.x || 4.x.x || 5.x.x || 6.x.x || 7.x.x || 8.x.x"
+    "firebase": "exp"
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",
@@ -50,7 +50,7 @@
     "@types/node": "^10.12.21",
     "chai": "^4.2.0",
     "coveralls": "^3.0.2",
-    "firebase": "^8.2.0",
+    "firebase": "exp",
     "jsdom": "^13.2.0",
     "jsdom-global": "^3.0.2",
     "mocha": "^5.2.0",

--- a/packages/geofire/package.json
+++ b/packages/geofire/package.json
@@ -42,7 +42,7 @@
     "geofire-common": "5.2.0"
   },
   "peerDependencies": {
-    "firebase": "exp"
+    "firebase": "9.0.0-beta.1"
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",
@@ -50,7 +50,7 @@
     "@types/node": "^10.12.21",
     "chai": "^4.2.0",
     "coveralls": "^3.0.2",
-    "firebase": "exp",
+    "firebase": "9.0.0-beta.1",
     "jsdom": "^13.2.0",
     "jsdom-global": "^3.0.2",
     "mocha": "^5.2.0",

--- a/packages/geofire/rollup.config.js
+++ b/packages/geofire/rollup.config.js
@@ -1,7 +1,7 @@
 import commonjs from 'rollup-plugin-commonjs';
 import resolveModule from 'rollup-plugin-node-resolve';
 import typescript from 'rollup-plugin-typescript2';
-import { uglify } from 'rollup-plugin-uglify';
+import { terser } from 'rollup-plugin-terser';
 import pkg from './package.json';
 
 const GLOBAL_NAME = 'geofire';
@@ -34,7 +34,7 @@ const completeBuilds = [{
       format: 'umd',
       name: GLOBAL_NAME
     },
-    plugins: [...plugins, uglify()]
+    plugins: [...plugins, terser()]
   },
   {
     input: 'src/index.ts',

--- a/packages/geofire/src/GeoFire.ts
+++ b/packages/geofire/src/GeoFire.ts
@@ -13,8 +13,7 @@ import { GeoQuery, QueryCriteria } from './GeoQuery';
 import { geohashForLocation, validateLocation, validateKey, Geopoint } from 'geofire-common';
 import { decodeGeoFireObject, encodeGeoFireObject } from './databaseUtils';
 
-import * as GeoFireTypes from './GeoFireTypes';
-import * as DatabaseTypes from '@firebase/database-types';
+import { Reference, DataSnapshot, child, update, get } from 'firebase/database';
 
 /**
  * Creates a GeoFire instance.
@@ -23,7 +22,7 @@ export class GeoFire {
   /**
    * @param _firebaseRef A Firebase reference where the GeoFire data will be stored.
    */
-  constructor(private _firebaseRef: DatabaseTypes.Reference) {
+  constructor(private _firebaseRef: Reference) {
     if (Object.prototype.toString.call(this._firebaseRef) !== '[object Object]') {
       throw new Error('firebaseRef must be an instance of Firebase');
     }
@@ -42,7 +41,7 @@ export class GeoFire {
    */
   public get(key: string): Promise<Geopoint> {
     validateKey(key);
-    return this._firebaseRef.child(key).once('value').then((dataSnapshot: DatabaseTypes.DataSnapshot) => {
+    return get(child(this._firebaseRef, key)).then((dataSnapshot: DataSnapshot) => {
       const snapshotVal = dataSnapshot.val();
       if (snapshotVal === null) {
         return null;
@@ -57,7 +56,7 @@ export class GeoFire {
    *
    * @returns The Firebase instance used to create this GeoFire instance.
    */
-  public ref(): DatabaseTypes.Reference {
+  public ref(): Reference {
     return this._firebaseRef;
   }
 
@@ -115,7 +114,7 @@ export class GeoFire {
       }
     });
 
-    return this._firebaseRef.update(newData);
+    return update(this._firebaseRef, newData);
   }
 
   /**

--- a/packages/geofire/src/GeoFire.ts
+++ b/packages/geofire/src/GeoFire.ts
@@ -13,7 +13,7 @@ import { GeoQuery, QueryCriteria } from './GeoQuery';
 import { geohashForLocation, validateLocation, validateKey, Geopoint } from 'geofire-common';
 import { decodeGeoFireObject, encodeGeoFireObject } from './databaseUtils';
 
-import { Reference, DataSnapshot, child, update, get } from 'firebase/database';
+import { DatabaseReference, DataSnapshot, child, update, get } from 'firebase/database';
 
 /**
  * Creates a GeoFire instance.
@@ -22,7 +22,7 @@ export class GeoFire {
   /**
    * @param _firebaseRef A Firebase reference where the GeoFire data will be stored.
    */
-  constructor(private _firebaseRef: Reference) {
+  constructor(private _firebaseRef: DatabaseReference) {
     if (Object.prototype.toString.call(this._firebaseRef) !== '[object Object]') {
       throw new Error('firebaseRef must be an instance of Firebase');
     }
@@ -56,7 +56,7 @@ export class GeoFire {
    *
    * @returns The Firebase instance used to create this GeoFire instance.
    */
-  public ref(): Reference {
+  public ref(): DatabaseReference {
     return this._firebaseRef;
   }
 

--- a/packages/geofire/src/GeoFireTypes.ts
+++ b/packages/geofire/src/GeoFireTypes.ts
@@ -1,5 +1,4 @@
 /* tslint:disable:no-import-side-effect no-namespace */
-import { DataSnapshot } from '@firebase/database-types';
 import { Geopoint, Geohash } from "geofire-common";
 
 export interface Document {

--- a/packages/geofire/src/GeoQuery.ts
+++ b/packages/geofire/src/GeoQuery.ts
@@ -6,7 +6,10 @@ import {
 import {
   decodeGeoFireObject, geoFireGetKey } from './databaseUtils';
 import * as GeoFireTypes from './GeoFireTypes';
-import { DataSnapshot, orderByChild, Reference, query, startAt, endAt, off, child, get, Query, onChildAdded, onChildRemoved, onChildChanged, onValue } from 'firebase/database';
+import { 
+  DataSnapshot, orderByChild, Reference, query, startAt, endAt, off, child, get, Query, onChildAdded, onChildRemoved,
+  onChildChanged, onValue 
+} from 'firebase/database';
 
 export interface QueryCriteria {
   center?: Geopoint;

--- a/packages/geofire/src/GeoQuery.ts
+++ b/packages/geofire/src/GeoQuery.ts
@@ -8,23 +8,19 @@ import {
 import * as GeoFireTypes from './GeoFireTypes';
 import { 
   DataSnapshot, orderByChild, DatabaseReference, query, startAt, endAt, off, child, get, Query, onChildAdded, onChildRemoved,
-  onChildChanged, onValue 
+  onChildChanged, onValue, Unsubscribe 
 } from 'firebase/database';
 
 export interface QueryCriteria {
   center?: Geopoint;
   radius?: number;
 }
-export type QueryStateCallback = (
-  a: DataSnapshot | null,
-  b?: string
-) => any;
 export interface QueryState {
   active: boolean;
-  childAddedCallback: QueryStateCallback;
-  childRemovedCallback: QueryStateCallback;
-  childChangedCallback: QueryStateCallback;
-  valueCallback: QueryStateCallback;
+  childAddedCallback: Unsubscribe;
+  childRemovedCallback: Unsubscribe;
+  childChangedCallback: Unsubscribe;
+  valueCallback: Unsubscribe;
 }
 /**
  * Validates the inputted query criteria and throws an error if it is invalid.
@@ -281,11 +277,10 @@ export class GeoQuery {
    * @param queryState An object storing the current state of the query.
    */
   private _cancelGeohashQuery(q: string[], queryState: QueryState): void {
-    const queryRef = query(this._firebaseRef, orderByChild('g'), startAt(q[0]), endAt(q[1]));
-    off(queryRef, 'child_added', queryState.childAddedCallback);
-    off(queryRef, 'child_removed', queryState.childRemovedCallback);
-    off(queryRef, 'child_changed', queryState.childChangedCallback);
-    off(queryRef, 'value', queryState.valueCallback);
+    queryState.childAddedCallback();
+    queryState.childRemovedCallback();
+    queryState.childChangedCallback();
+    queryState.valueCallback();
   }
 
   /**

--- a/packages/geofire/src/GeoQuery.ts
+++ b/packages/geofire/src/GeoQuery.ts
@@ -503,7 +503,7 @@ export class GeoQuery {
   /**
    * Encodes a query as a string for easier indexing and equality.
    *
-   * @param query The query to encode.
+   * @param q The query to encode.
    * @returns The encoded query as string.
    */
   private _queryToString(q: GeohashRange): string {

--- a/packages/geofire/src/GeoQuery.ts
+++ b/packages/geofire/src/GeoQuery.ts
@@ -7,7 +7,7 @@ import {
   decodeGeoFireObject, geoFireGetKey } from './databaseUtils';
 import * as GeoFireTypes from './GeoFireTypes';
 import { 
-  DataSnapshot, orderByChild, Reference, query, startAt, endAt, off, child, get, Query, onChildAdded, onChildRemoved,
+  DataSnapshot, orderByChild, DatabaseReference, query, startAt, endAt, off, child, get, Query, onChildAdded, onChildRemoved,
   onChildChanged, onValue 
 } from 'firebase/database';
 
@@ -92,7 +92,7 @@ export class GeoQuery {
    * @param _firebaseRef A Firebase reference where the GeoFire data will be stored.
    * @param queryCriteria The criteria which specifies the query's center and radius.
    */
-  constructor(private _firebaseRef: Reference, queryCriteria: QueryCriteria) {
+  constructor(private _firebaseRef: DatabaseReference, queryCriteria: QueryCriteria) {
     // Firebase reference of the GeoFire which created this query
     if (Object.prototype.toString.call(this._firebaseRef) !== '[object Object]') {
       throw new Error('firebaseRef must be an instance of Firebase');

--- a/packages/geofire/src/GeoQuery.ts
+++ b/packages/geofire/src/GeoQuery.ts
@@ -6,14 +6,14 @@ import {
 import {
   decodeGeoFireObject, geoFireGetKey } from './databaseUtils';
 import * as GeoFireTypes from './GeoFireTypes';
-import * as DatabaseTypes from '@firebase/database-types';
+import { DataSnapshot, orderByChild, Reference, query, startAt, endAt, off, child, get, Query, onChildAdded, onChildRemoved, onChildChanged, onValue } from 'firebase/database';
 
 export interface QueryCriteria {
   center?: Geopoint;
   radius?: number;
 }
 export type QueryStateCallback = (
-  a: DatabaseTypes.DataSnapshot | null,
+  a: DataSnapshot | null,
   b?: string
 ) => any;
 export interface QueryState {
@@ -89,7 +89,7 @@ export class GeoQuery {
    * @param _firebaseRef A Firebase reference where the GeoFire data will be stored.
    * @param queryCriteria The criteria which specifies the query's center and radius.
    */
-  constructor(private _firebaseRef: DatabaseTypes.Reference, queryCriteria: QueryCriteria) {
+  constructor(private _firebaseRef: Reference, queryCriteria: QueryCriteria) {
     // Firebase reference of the GeoFire which created this query
     if (Object.prototype.toString.call(this._firebaseRef) !== '[object Object]') {
       throw new Error('firebaseRef must be an instance of Firebase');
@@ -130,8 +130,8 @@ export class GeoQuery {
     // Turn off all Firebase listeners for the current geohashes being queried
     const keys: string[] = Object.keys(this._currentGeohashesQueried);
     keys.forEach((geohashQueryStr: string) => {
-      const query: string[] = this._stringToQuery(geohashQueryStr);
-      this._cancelGeohashQuery(query, this._currentGeohashesQueried[geohashQueryStr]);
+      const q: string[] = this._stringToQuery(geohashQueryStr);
+      this._cancelGeohashQuery(q, this._currentGeohashesQueried[geohashQueryStr]);
       delete this._currentGeohashesQueried[geohashQueryStr];
     });
 
@@ -277,12 +277,12 @@ export class GeoQuery {
    * @param query The geohash query.
    * @param queryState An object storing the current state of the query.
    */
-  private _cancelGeohashQuery(query: string[], queryState: QueryState): void {
-    const queryRef = this._firebaseRef.orderByChild('g').startAt(query[0]).endAt(query[1]);
-    queryRef.off('child_added', queryState.childAddedCallback);
-    queryRef.off('child_removed', queryState.childRemovedCallback);
-    queryRef.off('child_changed', queryState.childChangedCallback);
-    queryRef.off('value', queryState.valueCallback);
+  private _cancelGeohashQuery(q: string[], queryState: QueryState): void {
+    const queryRef = query(this._firebaseRef, orderByChild('g'), startAt(q[0]), endAt(q[1]));
+    off(queryRef, 'child_added', queryState.childAddedCallback);
+    off(queryRef, 'child_removed', queryState.childRemovedCallback);
+    off(queryRef, 'child_changed', queryState.childChangedCallback);
+    off(queryRef, 'value', queryState.valueCallback);
   }
 
   /**
@@ -290,7 +290,7 @@ export class GeoQuery {
    *
    * @param locationDataSnapshot A snapshot of the data stored for this location.
    */
-  private _childAddedCallback(locationDataSnapshot: DatabaseTypes.DataSnapshot): void {
+  private _childAddedCallback(locationDataSnapshot: DataSnapshot): void {
     this._updateLocation(geoFireGetKey(locationDataSnapshot), decodeGeoFireObject(locationDataSnapshot.val()));
   }
 
@@ -299,7 +299,7 @@ export class GeoQuery {
    *
    * @param locationDataSnapshot A snapshot of the data stored for this location.
    */
-  private _childChangedCallback(locationDataSnapshot: DatabaseTypes.DataSnapshot): void {
+  private _childChangedCallback(locationDataSnapshot: DataSnapshot): void {
     this._updateLocation(geoFireGetKey(locationDataSnapshot), decodeGeoFireObject(locationDataSnapshot.val()));
   }
 
@@ -308,10 +308,10 @@ export class GeoQuery {
    *
    * @param locationDataSnapshot A snapshot of the data stored for this location.
    */
-  private _childRemovedCallback(locationDataSnapshot: DatabaseTypes.DataSnapshot): void {
+  private _childRemovedCallback(locationDataSnapshot: DataSnapshot): void {
     const key: string = geoFireGetKey(locationDataSnapshot);
     if (key in this._locationsTracked) {
-      this._firebaseRef.child(key).once('value', (snapshot: DatabaseTypes.DataSnapshot) => {
+      get(child(this._firebaseRef, key)).then((snapshot: DataSnapshot) => {
         const location: Geopoint = (snapshot.val() === null) ? null : decodeGeoFireObject(snapshot.val());
         const geohash: Geohash = (location !== null) ? geohashForLocation(location) : null;
         // Only notify observers if key is not part of any other geohash query or this actually might not be
@@ -466,21 +466,21 @@ export class GeoQuery {
     // Once every geohash to query is processed, fire the 'ready' event.
     geohashesToQuery.forEach((toQueryStr: string) => {
       // decode the geohash query string
-      const query: string[] = this._stringToQuery(toQueryStr);
+      const q: string[] = this._stringToQuery(toQueryStr);
 
       // Create the Firebase query
-      const firebaseQuery: DatabaseTypes.Query = this._firebaseRef.orderByChild('g').startAt(query[0]).endAt(query[1]);
+      const firebaseQuery: Query = query(this._firebaseRef, orderByChild('g'), startAt(q[0]), endAt(q[1]));
 
       // For every new matching geohash, determine if we should fire the 'key_entered' event
-      const childAddedCallback = firebaseQuery.on('child_added', (a) => this._childAddedCallback(a));
-      const childRemovedCallback = firebaseQuery.on('child_removed', (a) => this._childRemovedCallback(a));
-      const childChangedCallback = firebaseQuery.on('child_changed', (a) => this._childChangedCallback(a));
+      const childAddedCallback = onChildAdded(firebaseQuery, (a) => this._childAddedCallback(a));
+      const childRemovedCallback = onChildRemoved(firebaseQuery, (a) => this._childRemovedCallback(a));
+      const childChangedCallback = onChildChanged( firebaseQuery, (a) => this._childChangedCallback(a));
 
       // Once the current geohash to query is processed, see if it is the last one to be processed
       // and, if so, mark the value event as fired.
       // Note that Firebase fires the 'value' event after every 'child_added' event fires.
-      const valueCallback = firebaseQuery.on('value', () => {
-        firebaseQuery.off('value', valueCallback);
+      const valueCallback = onValue(firebaseQuery, () => {
+        off(firebaseQuery, 'value', valueCallback);
         this._geohashQueryReadyCallback(toQueryStr);
       });
 
@@ -508,11 +508,11 @@ export class GeoQuery {
    * @param query The query to encode.
    * @returns The encoded query as string.
    */
-  private _queryToString(query: GeohashRange): string {
-    if (query.length !== 2) {
-      throw new Error('Not a valid geohash query: ' + query);
+  private _queryToString(q: GeohashRange): string {
+    if (q.length !== 2) {
+      throw new Error('Not a valid geohash query: ' + q);
     }
-    return query[0] + ':' + query[1];
+    return q[0] + ':' + q[1];
   }
 
   /**

--- a/packages/geofire/src/databaseUtils.ts
+++ b/packages/geofire/src/databaseUtils.ts
@@ -1,6 +1,6 @@
 import { Document } from './GeoFireTypes';
 import { validateLocation, validateGeohash, Geopoint, Geohash } from "geofire-common";
-import { DataSnapshot } from '@firebase/database-types';
+import { DataSnapshot } from 'firebase/database';
 
 /**
  * Encodes a location and geohash as a GeoFire object.

--- a/packages/geofire/test/common.ts
+++ b/packages/geofire/test/common.ts
@@ -1,7 +1,7 @@
 /* tslint:disable:max-line-length */
 import * as chai from 'chai';
 import { initializeApp } from 'firebase/app';
-import { Reference, getDatabase, ref, push, remove, get, DataSnapshot } from 'firebase/database';
+import { DatabaseReference, getDatabase, ref, push, remove, get, DataSnapshot } from 'firebase/database';
 
 import { GeoFire, GeoQuery, QueryCallbacks } from '../src';
 import { QueryCriteria } from '../src/GeoQuery';
@@ -23,7 +23,7 @@ export const validQueryCriterias: QueryCriteria[] = [{ center: [0, 0], radius: 1
 export const invalidQueryCriterias = [{}, { random: 100 }, { center: [91, 2], radius: 1000, random: 'a' }, { center: [91, 2], radius: 1000 }, { center: [1, -181], radius: 1000 }, { center: ['a', 2], radius: 1000 }, { center: [1, [1, 2]], radius: 1000 }, { center: [0, 0], radius: -1 }, { center: [null, 2], radius: 1000 }, { center: [1, undefined], radius: 1000 }, { center: [NaN, 0], radius: 1000 }, { center: [1, 2], radius: -10 }, { center: [1, 2], radius: 'text' }, { center: [1, 2], radius: [1, 2] }, { center: [1, 2], radius: null }, true, false, undefined, NaN, [], 'a', 1];
 
 // Create global constiables to hold the Firebase and GeoFire constiables
-export let geoFireRef: Reference,
+export let geoFireRef: DatabaseReference,
   geoFire: GeoFire,
   geoQueries: GeoQuery[] = [];
 


### PR DESCRIPTION
### Description

This PR should update geofire to use the new modular firebase sdk (v9).
I simply copied the changes from #217 and made small improvements with as little code changes as possible to fix the build. These include:
- replace the `uglify` plugin with `terser`
- use the stable version of firebase v9 instead of the beta
- bump the node version on GitHub actions to 10.x (minimum required by v9)

#### TODO:
- [x] Docs
- [x] Migration guide
- [x] Examples
- [x] Remove exp version
- [ ] Major version bump

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->
