### PR TITLE
wrap off(firebaseQuery, 'value', valueUnsubscribe) in setTimeout-0

### DIFF
--- a/packages/geofire/src/GeoQuery.ts
+++ b/packages/geofire/src/GeoQuery.ts
@@ -478,8 +478,10 @@ export class GeoQuery {
       // and, if so, mark the value event as fired.
       // Note that Firebase fires the 'value' event after every 'child_added' event fires.
       const valueUnsubscribe = onValue(firebaseQuery, () => {
-        off(firebaseQuery, 'value', valueUnsubscribe);
-        this._geohashQueryReadyCallback(toQueryStr);
+        setTimeout(() => {
+          off(firebaseQuery, 'value', valueUnsubscribe);
+          this._geohashQueryReadyCallback(toQueryStr);
+        }, 0);
       });
 
       // Add the geohash query to the current geohashes queried dictionary and save its state

--- a/packages/geofire/src/GeoQuery.ts
+++ b/packages/geofire/src/GeoQuery.ts
@@ -479,7 +479,7 @@ export class GeoQuery {
       // Note that Firebase fires the 'value' event after every 'child_added' event fires.
       const valueUnsubscribe = onValue(firebaseQuery, () => {
         setTimeout(() => {
-          off(firebaseQuery, 'value', valueUnsubscribe);
+          valueUnsubscribe();
           this._geohashQueryReadyCallback(toQueryStr);
         }, 0);
       });


### PR DESCRIPTION
### Description

In some cases (especially when frequently subscribing and unsubscribing geo queries) there was an error: 

> Uncaught ReferenceError: Cannot access 'valueUnsubscribe' before initialization
> at GeoQuery.ts:485:37


It seems that in those cases the callback provided to onValue was called synchronously before returning valueUnsubscribe from the function call. Therefore valueUnsubscribe was not yet fully defined (Temporal Dead Zone ?)


   

