### PR TITLE
ci: run tests against Firebase emulator

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,10 +13,11 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 14.x
+          - 20.x
+          - 22.x
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -30,6 +31,10 @@ jobs:
       - run: npm run bootstrap
       - run: npm run lint
       - run: npm run test
+      - name: Run tests against emulator
+        run: |
+          npm install -g firebase-tools
+          firebase emulators:exec --only database --project fake-project-id 'npm run test'
       - run: npm run coverage
 
       - name: Coveralls

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,7 +30,6 @@ jobs:
       - run: npm install
       - run: npm run bootstrap
       - run: npm run lint
-      - run: npm run test
       - name: Run tests against emulator
         run: |
           npm install -g firebase-tools

--- a/examples/fish1/js/fish1.js
+++ b/examples/fish1/js/fish1.js
@@ -1,9 +1,10 @@
 (function() {
   // Initialize the Firebase SDK
+  // TODO(DEVELOPER): Change the values below using values from the initialization snippet: Firebase Console > Overview > Add Firebase to your web app.
   initializeApp({
-    apiKey: "AIzaSyCR4ND2xwX3kU1IxTn0youF5OlI3x6MFZs",
-    databaseURL: "https://geofire-gh-tests.firebaseio.com",
-    projectId: "geofire-gh-tests"
+    apiKey: "<YOUR_API_KEY>",
+    databaseURL: "<YOUR_DB_URL>",
+    projectId: "<YOUR_PROJECT_ID>"
   });
 
   // Generate a random Firebase location

--- a/examples/fish2/js/fish2.js
+++ b/examples/fish2/js/fish2.js
@@ -1,9 +1,9 @@
 (function() {
   // Initialize the Firebase SDK
   initializeApp({
-    apiKey: "sAIzaSyCR4ND2xwX3kU1IxTn0youF5OlI3x6MFZs",
-    databaseURL: "https://geofire-gh-tests.firebaseio.com",
-    projectId: "geofire-gh-tests"
+    apiKey: "s<YOUR_API_KEY>",
+    databaseURL: "<YOUR_DB_URL>",
+    projectId: "<YOUR_PROJECT_ID>"
   });
 
   // Generate a random Firebase location

--- a/examples/fish3/js/fish3.js
+++ b/examples/fish3/js/fish3.js
@@ -1,9 +1,9 @@
 (function() {
   // Initialize the Firebase SDK
   initializeApp({
-    apiKey: "AIzaSyCR4ND2xwX3kU1IxTn0youF5OlI3x6MFZs",
-    databaseURL: "https://geofire-gh-tests.firebaseio.com",
-    projectId: "geofire-gh-tests"
+    apiKey: "<YOUR_API_KEY>",
+    databaseURL: "<YOUR_DB_URL>",
+    projectId: "<YOUR_PROJECT_ID>"
   });
 
   // Generate a random Firebase location

--- a/examples/html5Geolocation/js/html5Geolocation.js
+++ b/examples/html5Geolocation/js/html5Geolocation.js
@@ -1,9 +1,9 @@
 (function() {
   // Initialize the Firebase SDK
   initializeApp({
-    apiKey: "AIzaSyCR4ND2xwX3kU1IxTn0youF5OlI3x6MFZs",
-    databaseURL: "https://geofire-gh-tests.firebaseio.com",
-    projectId: "geofire-gh-tests"
+    apiKey: "<YOUR_API_KEY>",
+    databaseURL: "<YOUR_DB_URL>",
+    projectId: "<YOUR_PROJECT_ID>"
   });
 
   // Generate a random Firebase location

--- a/examples/queryBuilder/js/queryBuilder.js
+++ b/examples/queryBuilder/js/queryBuilder.js
@@ -1,9 +1,9 @@
 (function() {
   // Initialize the Firebase SDK
   initializeApp({
-    apiKey: "AIzaSyCR4ND2xwX3kU1IxTn0youF5OlI3x6MFZs",
-    databaseURL: "https://geofire-gh-tests.firebaseio.com",
-    projectId: "geofire-gh-tests"
+    apiKey: "<YOUR_API_KEY>",
+    databaseURL: "<YOUR_DB_URL>",
+    projectId: "<YOUR_PROJECT_ID>"
   });
 
   // Generate a random Firebase location

--- a/packages/geofire/test/common.ts
+++ b/packages/geofire/test/common.ts
@@ -29,9 +29,9 @@ export let geoFireRef: DatabaseReference,
 
 // Initialize Firebase
 const config = {
-  apiKey: 'AIzaSyCR4ND2xwX3kU1IxTn0youF5OlI3x6MFZs',
-  databaseURL: 'https://geofire-gh-tests.firebaseio.com',
-  projectId: 'geofire-gh-tests'
+  apiKey: '<YOUR_API_KEY>',
+  databaseURL: '<YOUR_DB_URL>',
+  projectId: '<YOUR_PROJECT_ID>'
 };
 initializeApp(config);
 

--- a/packages/geofire/test/common.ts
+++ b/packages/geofire/test/common.ts
@@ -30,8 +30,8 @@ export let geoFireRef: DatabaseReference,
 // Initialize Firebase
 const config = {
   apiKey: '<YOUR_API_KEY>',
-  databaseURL: '<YOUR_DB_URL>',
-  projectId: '<YOUR_PROJECT_ID>'
+  databaseURL: 'https://fake-project-id.firebaseio.com',
+  projectId: 'fake-project-id'
 };
 initializeApp(config);
 


### PR DESCRIPTION
This PR should upgrade our CI to:
- use versions 20 and 22 of NodeJS
- use the latest versions of GH Actions
- run the automated tests against the emulator instead of an actual Firebase project (it used to be `geofire-gh-tests`)
- use placeholders for the Firebase configuration in the examples

I went ahead and changed the rules in that project to not allow any writes or reads. _(internal bug: [b/324238753](http://b/324238753))_